### PR TITLE
feat: 플랫폼 등록 및 목록 조회 API 추가

### DIFF
--- a/api/src/main/java/com/nextdv/api/platform/PlatformController.java
+++ b/api/src/main/java/com/nextdv/api/platform/PlatformController.java
@@ -1,0 +1,66 @@
+package com.nextdv.api.platform;
+
+import com.nextdv.api.common.ApiResponse;
+import com.nextdv.domain.platform.Platform;
+import com.nextdv.domain.platform.PlatformService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/platforms")
+@RequiredArgsConstructor
+public class PlatformController {
+
+  private static final int DEFAULT_TIMEOUT_MS = 3000;
+  private static final int DEFAULT_DEGRADED_THRESHOLD_MS = 1000;
+
+  private final PlatformService platformService;
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<PlatformResponse>>> list() {
+    List<Platform> platforms = platformService.findAll();
+    return ResponseEntity.ok(
+        ApiResponse.ok(
+            PlatformMapper.toResponseList(
+                platforms
+            )
+        )
+    );
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<PlatformResponse>> register(
+      @RequestBody PlatformRegisterRequest request) {
+    int timeoutMs = DEFAULT_TIMEOUT_MS;
+    if (request.getTimeoutMs() != null) {
+      timeoutMs = request.getTimeoutMs();
+    }
+    int degradedThresholdMs = DEFAULT_DEGRADED_THRESHOLD_MS;
+    if (request.getDegradedThresholdMs() != null) {
+      degradedThresholdMs = request.getDegradedThresholdMs();
+    }
+    Platform platform = platformService.register(
+        request.getName(),
+        request.getCategory(),
+        request.getHealthCheckUrl(),
+        timeoutMs,
+        degradedThresholdMs,
+        request.getIconUrl()
+    );
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(
+            ApiResponse.ok(
+                PlatformMapper.toResponse(
+                    platform
+                )
+            )
+        );
+  }
+}

--- a/api/src/main/java/com/nextdv/api/platform/PlatformMapper.java
+++ b/api/src/main/java/com/nextdv/api/platform/PlatformMapper.java
@@ -1,0 +1,28 @@
+package com.nextdv.api.platform;
+
+import com.nextdv.domain.platform.Platform;
+import java.util.List;
+
+public class PlatformMapper {
+
+  private PlatformMapper() {
+  }
+
+  public static PlatformResponse toResponse(Platform platform) {
+    return new PlatformResponse(
+        platform.getId(),
+        platform.getName(),
+        platform.getCategory(),
+        platform.getHealthCheckUrl(),
+        platform.getTimeoutMs(),
+        platform.getDegradedThresholdMs(),
+        platform.getIconUrl(),
+        platform.isActive()
+    );
+  }
+
+  public static List<PlatformResponse> toResponseList(
+      List<Platform> platforms) {
+    return platforms.stream().map(PlatformMapper::toResponse).toList();
+  }
+}

--- a/api/src/main/java/com/nextdv/api/platform/PlatformRegisterRequest.java
+++ b/api/src/main/java/com/nextdv/api/platform/PlatformRegisterRequest.java
@@ -1,0 +1,61 @@
+package com.nextdv.api.platform;
+
+import com.nextdv.domain.platform.ServiceCategory;
+
+public class PlatformRegisterRequest {
+
+  private String name;
+  private ServiceCategory category;
+  private String healthCheckUrl;
+  private Integer timeoutMs;
+  private Integer degradedThresholdMs;
+  private String iconUrl;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public ServiceCategory getCategory() {
+    return category;
+  }
+
+  public void setCategory(ServiceCategory category) {
+    this.category = category;
+  }
+
+  public String getHealthCheckUrl() {
+    return healthCheckUrl;
+  }
+
+  public void setHealthCheckUrl(String healthCheckUrl) {
+    this.healthCheckUrl = healthCheckUrl;
+  }
+
+  public Integer getTimeoutMs() {
+    return timeoutMs;
+  }
+
+  public void setTimeoutMs(Integer timeoutMs) {
+    this.timeoutMs = timeoutMs;
+  }
+
+  public Integer getDegradedThresholdMs() {
+    return degradedThresholdMs;
+  }
+
+  public void setDegradedThresholdMs(Integer degradedThresholdMs) {
+    this.degradedThresholdMs = degradedThresholdMs;
+  }
+
+  public String getIconUrl() {
+    return iconUrl;
+  }
+
+  public void setIconUrl(String iconUrl) {
+    this.iconUrl = iconUrl;
+  }
+}

--- a/api/src/main/java/com/nextdv/api/platform/PlatformResponse.java
+++ b/api/src/main/java/com/nextdv/api/platform/PlatformResponse.java
@@ -1,0 +1,67 @@
+package com.nextdv.api.platform;
+
+import com.nextdv.domain.platform.ServiceCategory;
+import java.util.UUID;
+
+public class PlatformResponse {
+
+  private final UUID id;
+  private final String name;
+  private final ServiceCategory category;
+  private final String healthCheckUrl;
+  private final int timeoutMs;
+  private final int degradedThresholdMs;
+  private final String iconUrl;
+  private final boolean active;
+
+  public PlatformResponse(
+      UUID id,
+      String name,
+      ServiceCategory category,
+      String healthCheckUrl,
+      int timeoutMs,
+      int degradedThresholdMs,
+      String iconUrl,
+      boolean active) {
+    this.id = id;
+    this.name = name;
+    this.category = category;
+    this.healthCheckUrl = healthCheckUrl;
+    this.timeoutMs = timeoutMs;
+    this.degradedThresholdMs = degradedThresholdMs;
+    this.iconUrl = iconUrl;
+    this.active = active;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ServiceCategory getCategory() {
+    return category;
+  }
+
+  public String getHealthCheckUrl() {
+    return healthCheckUrl;
+  }
+
+  public int getTimeoutMs() {
+    return timeoutMs;
+  }
+
+  public int getDegradedThresholdMs() {
+    return degradedThresholdMs;
+  }
+
+  public String getIconUrl() {
+    return iconUrl;
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+}

--- a/config/eclipse/formatter.xml
+++ b/config/eclipse/formatter.xml
@@ -6,7 +6,7 @@
     <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
     <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="2"/>
     <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="2"/>
-    <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="100"/>
+    <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="80"/>
     <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
 
     <!-- 메소드 체이닝/중첩: 줄 길이 무관하게 호출마다 줄바꿈 강제 -->

--- a/domain/src/main/java/com/nextdv/domain/platform/Platform.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/Platform.java
@@ -1,0 +1,66 @@
+package com.nextdv.domain.platform;
+
+import java.util.UUID;
+
+public class Platform {
+
+  private final UUID id;
+  private final String name;
+  private final ServiceCategory category;
+  private final String healthCheckUrl;
+  private final int timeoutMs;
+  private final int degradedThresholdMs;
+  private final String iconUrl;
+  private final boolean active;
+
+  public Platform(
+      UUID id,
+      String name,
+      ServiceCategory category,
+      String healthCheckUrl,
+      int timeoutMs,
+      int degradedThresholdMs,
+      String iconUrl,
+      boolean active) {
+    this.id = id;
+    this.name = name;
+    this.category = category;
+    this.healthCheckUrl = healthCheckUrl;
+    this.timeoutMs = timeoutMs;
+    this.degradedThresholdMs = degradedThresholdMs;
+    this.iconUrl = iconUrl;
+    this.active = active;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ServiceCategory getCategory() {
+    return category;
+  }
+
+  public String getHealthCheckUrl() {
+    return healthCheckUrl;
+  }
+
+  public int getTimeoutMs() {
+    return timeoutMs;
+  }
+
+  public int getDegradedThresholdMs() {
+    return degradedThresholdMs;
+  }
+
+  public String getIconUrl() {
+    return iconUrl;
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+}

--- a/domain/src/main/java/com/nextdv/domain/platform/PlatformRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/PlatformRepository.java
@@ -1,0 +1,10 @@
+package com.nextdv.domain.platform;
+
+import java.util.List;
+
+public interface PlatformRepository {
+
+  List<Platform> findAll();
+
+  Platform save(Platform platform);
+}

--- a/domain/src/main/java/com/nextdv/domain/platform/PlatformService.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/PlatformService.java
@@ -1,0 +1,37 @@
+package com.nextdv.domain.platform;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlatformService {
+
+  private final PlatformRepository platformRepository;
+
+  public List<Platform> findAll() {
+    return platformRepository.findAll();
+  }
+
+  public Platform register(
+      String name,
+      ServiceCategory category,
+      String healthCheckUrl,
+      int timeoutMs,
+      int degradedThresholdMs,
+      String iconUrl) {
+    Platform platform = new Platform(
+        UUID.randomUUID(),
+        name,
+        category,
+        healthCheckUrl,
+        timeoutMs,
+        degradedThresholdMs,
+        iconUrl,
+        true
+    );
+    return platformRepository.save(platform);
+  }
+}

--- a/domain/src/main/java/com/nextdv/domain/platform/ServiceCategory.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/ServiceCategory.java
@@ -1,0 +1,5 @@
+package com.nextdv.domain.platform;
+
+public enum ServiceCategory {
+  CLOUD, AI, COMMUNICATION, DEVTOOL, OTHER
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformEntity.java
@@ -1,0 +1,94 @@
+package com.nextdv.infrastructure.platform;
+
+import com.nextdv.domain.platform.ServiceCategory;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+
+@Entity
+@Table(name = "platforms")
+public class PlatformEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(nullable = false, length = 100)
+  private String name;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ServiceCategory category;
+
+  @Column(name = "health_check_url", nullable = false, length = 500)
+  private String healthCheckUrl;
+
+  @Column(name = "timeout_ms", nullable = false)
+  private int timeoutMs;
+
+  @Column(name = "degraded_threshold_ms", nullable = false)
+  private int degradedThresholdMs;
+
+  @Column(name = "icon_url", length = 500)
+  private String iconUrl;
+
+  @Column(name = "is_active", nullable = false)
+  private boolean isActive;
+
+  protected PlatformEntity() {
+  }
+
+  public PlatformEntity(
+      UUID id,
+      String name,
+      ServiceCategory category,
+      String healthCheckUrl,
+      int timeoutMs,
+      int degradedThresholdMs,
+      String iconUrl,
+      boolean isActive) {
+    this.id = id;
+    this.name = name;
+    this.category = category;
+    this.healthCheckUrl = healthCheckUrl;
+    this.timeoutMs = timeoutMs;
+    this.degradedThresholdMs = degradedThresholdMs;
+    this.iconUrl = iconUrl;
+    this.isActive = isActive;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ServiceCategory getCategory() {
+    return category;
+  }
+
+  public String getHealthCheckUrl() {
+    return healthCheckUrl;
+  }
+
+  public int getTimeoutMs() {
+    return timeoutMs;
+  }
+
+  public int getDegradedThresholdMs() {
+    return degradedThresholdMs;
+  }
+
+  public String getIconUrl() {
+    return iconUrl;
+  }
+
+  public boolean isActive() {
+    return isActive;
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformJpaRepository.java
@@ -1,0 +1,9 @@
+package com.nextdv.infrastructure.platform;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlatformJpaRepository
+    extends
+      JpaRepository<PlatformEntity, UUID> {
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.nextdv.infrastructure.platform;
+
+import com.nextdv.domain.platform.Platform;
+import com.nextdv.domain.platform.PlatformRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PlatformRepositoryImpl implements PlatformRepository {
+
+  private final PlatformJpaRepository platformJpaRepository;
+
+  @Override
+  public List<Platform> findAll() {
+    return platformJpaRepository.findAll().stream().map(this::toDomain)
+        .toList();
+  }
+
+  @Override
+  public Platform save(Platform platform) {
+    PlatformEntity saved = platformJpaRepository.save(toEntity(platform));
+    return toDomain(saved);
+  }
+
+  private Platform toDomain(PlatformEntity entity) {
+    return new Platform(
+        entity.getId(),
+        entity.getName(),
+        entity.getCategory(),
+        entity.getHealthCheckUrl(),
+        entity.getTimeoutMs(),
+        entity.getDegradedThresholdMs(),
+        entity.getIconUrl(),
+        entity.isActive()
+    );
+  }
+
+  private PlatformEntity toEntity(Platform platform) {
+    return new PlatformEntity(
+        platform.getId(),
+        platform.getName(),
+        platform.getCategory(),
+        platform.getHealthCheckUrl(),
+        platform.getTimeoutMs(),
+        platform.getDegradedThresholdMs(),
+        platform.getIconUrl(),
+        platform.isActive()
+    );
+  }
+}

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/account/AccountServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/account/AccountServiceTest.java
@@ -25,7 +25,9 @@ class AccountServiceTest {
 
   @Container
   @ServiceConnection
-  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
+      "postgres:16-alpine"
+  );
 
   @Autowired
   private AccountJpaRepository jpaRepository;

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/platform/PlatformServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/platform/PlatformServiceTest.java
@@ -1,0 +1,83 @@
+package com.nextdv.infrastructure.platform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nextdv.domain.platform.Platform;
+import com.nextdv.domain.platform.PlatformService;
+import com.nextdv.domain.platform.ServiceCategory;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import({PlatformRepositoryImpl.class, PlatformService.class})
+@Testcontainers
+class PlatformServiceTest {
+
+  @Container
+  @ServiceConnection
+  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
+      "postgres:16-alpine"
+  );
+
+  @Autowired
+  private PlatformJpaRepository jpaRepository;
+
+  @Autowired
+  private PlatformService platformService;
+
+  @Test
+  void 플랫폼을_등록한다() {
+    Platform result = platformService.register(
+        "GitHub",
+        ServiceCategory.DEVTOOL,
+        "https://api.github.com",
+        3000,
+        1000,
+        null
+    );
+
+    assertThat(result.getId()).isNotNull();
+    assertThat(result.getName()).isEqualTo("GitHub");
+    assertThat(result.getCategory()).isEqualTo(ServiceCategory.DEVTOOL);
+    assertThat(result.getHealthCheckUrl()).isEqualTo("https://api.github.com");
+    assertThat(result.isActive()).isTrue();
+  }
+
+  @Test
+  void 등록된_플랫폼을_전체_조회한다() {
+    platformService.register(
+        "GitHub",
+        ServiceCategory.DEVTOOL,
+        "https://api.github.com",
+        3000,
+        1000,
+        null
+    );
+    platformService.register(
+        "AWS",
+        ServiceCategory.CLOUD,
+        "https://health.aws.amazon.com",
+        3000,
+        1000,
+        null
+    );
+
+    List<Platform> result = platformService.findAll();
+
+    assertThat(result).hasSize(2);
+    assertThat(result).extracting(Platform::getName).containsExactlyInAnyOrder(
+        "GitHub",
+        "AWS"
+    );
+  }
+}


### PR DESCRIPTION
## 요약
- `POST /platforms` — 플랫폼 등록 (name, category, healthCheckUrl, timeoutMs, degradedThresholdMs, iconUrl)
- `GET /platforms` — 전체 플랫폼 목록 조회
- `platforms` 테이블 기준 domain/infrastructure/api 3모듈 구조로 구현

## 작업사항
- `ServiceCategory` enum (CLOUD, AI, COMMUNICATION, DEVTOOL, OTHER)
- `Platform` 도메인 객체 및 `PlatformRepository` 인터페이스
- `PlatformService` — UUID 생성, 기본값(timeoutMs: 3000, degradedThresholdMs: 1000) 적용
- `PlatformEntity` / `PlatformJpaRepository` / `PlatformRepositoryImpl`
- `PlatformController` / `PlatformMapper` / `PlatformRegisterRequest` / `PlatformResponse`
- `PlatformServiceTest` — TestContainers(PostgreSQL 16) 통합 테스트
- Eclipse formatter `lineSplit` 80으로 조정 (Checkstyle LineLength와 일치)

## 기타
- Swagger UI(`/swagger-ui.html`)로 테스트 가능