### PR TITLE
feat(channel): 채널 도메인/인프라 레이어 추가

### DIFF
--- a/domain/src/main/java/com/nextdv/domain/channel/Channel.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/Channel.java
@@ -1,0 +1,38 @@
+package com.nextdv.domain.channel;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class Channel {
+
+  private final UUID id;
+  private final UUID userId;
+  private final ChannelType type;
+  private final String name;
+  private final Map<String, Object> config;
+  private final Instant createdAt;
+  private final Instant updatedAt;
+  private final Instant deletedAt;
+
+  public Channel(
+      UUID id,
+      UUID userId,
+      ChannelType type,
+      String name,
+      Map<String, Object> config,
+      Instant createdAt,
+      Instant updatedAt,
+      Instant deletedAt) {
+    this.id = id;
+    this.userId = userId;
+    this.type = type;
+    this.name = name;
+    this.config = config;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.deletedAt = deletedAt;
+  }
+}

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelRepository.java
@@ -1,0 +1,14 @@
+package com.nextdv.domain.channel;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ChannelRepository {
+
+  Channel save(Channel channel);
+
+  List<Channel> findAllByUserId(UUID userId);
+
+  Optional<Channel> findById(UUID id);
+}

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelService.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelService.java
@@ -1,0 +1,43 @@
+package com.nextdv.domain.channel;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChannelService {
+
+  private final ChannelRepository channelRepository;
+
+  public Channel create(
+      UUID userId, ChannelType type, String name, Map<String, Object> config) {
+    Instant now = Instant.now();
+    Channel channel = new Channel(UUID.randomUUID(), userId, type, name, config, now, now, null);
+    return channelRepository.save(channel);
+  }
+
+  public List<Channel> findAllByUserId(UUID userId) {
+    return channelRepository.findAllByUserId(userId);
+  }
+
+  public void delete(UUID id) {
+    Channel channel = channelRepository
+        .findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("채널을 찾을 수 없습니다."));
+    Channel deleted = new Channel(
+        channel.getId(),
+        channel.getUserId(),
+        channel.getType(),
+        channel.getName(),
+        channel.getConfig(),
+        channel.getCreatedAt(),
+        Instant.now(),
+        Instant.now()
+    );
+    channelRepository.save(deleted);
+  }
+}

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelType.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelType.java
@@ -1,0 +1,5 @@
+package com.nextdv.domain.channel;
+
+public enum ChannelType {
+  SLACK, DISCORD, APP, EMAIL
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelEntity.java
@@ -10,13 +10,17 @@ import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "channels")
 @Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class ChannelEntity {
 
   @Id
@@ -45,25 +49,4 @@ public class ChannelEntity {
   @Column(name = "deleted_at")
   private Instant deletedAt;
 
-  protected ChannelEntity() {
-  }
-
-  public ChannelEntity(
-      UUID id,
-      UUID userId,
-      ChannelType type,
-      String name,
-      Map<String, Object> config,
-      Instant createdAt,
-      Instant updatedAt,
-      Instant deletedAt) {
-    this.id = id;
-    this.userId = userId;
-    this.type = type;
-    this.name = name;
-    this.config = config;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
-    this.deletedAt = deletedAt;
-  }
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelEntity.java
@@ -1,0 +1,69 @@
+package com.nextdv.infrastructure.channel;
+
+import com.nextdv.domain.channel.ChannelType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Getter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "channels")
+@Getter
+public class ChannelEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(name = "user_id", nullable = false)
+  private UUID userId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(columnDefinition = "channel_type", nullable = false)
+  private ChannelType type;
+
+  @Column(nullable = false, length = 100)
+  private String name;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private Map<String, Object> config;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  @Column(name = "deleted_at")
+  private Instant deletedAt;
+
+  protected ChannelEntity() {
+  }
+
+  public ChannelEntity(
+      UUID id,
+      UUID userId,
+      ChannelType type,
+      String name,
+      Map<String, Object> config,
+      Instant createdAt,
+      Instant updatedAt,
+      Instant deletedAt) {
+    this.id = id;
+    this.userId = userId;
+    this.type = type;
+    this.name = name;
+    this.config = config;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.deletedAt = deletedAt;
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelEntity.java
@@ -1,6 +1,5 @@
 package com.nextdv.infrastructure.channel;
 
-import com.nextdv.domain.channel.ChannelType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -31,7 +30,7 @@ public class ChannelEntity {
 
   @Enumerated(EnumType.STRING)
   @Column(columnDefinition = "channel_type", nullable = false)
-  private ChannelType type;
+  private ChannelTypeEntity type;
 
   @Column(nullable = false, length = 100)
   private String name;

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelJpaRepository.java
@@ -1,0 +1,10 @@
+package com.nextdv.infrastructure.channel;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChannelJpaRepository extends JpaRepository<ChannelEntity, UUID> {
+
+  List<ChannelEntity> findAllByUserIdAndDeletedAtIsNull(UUID userId);
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.nextdv.infrastructure.channel;
+
+import com.nextdv.domain.channel.Channel;
+import com.nextdv.domain.channel.ChannelRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChannelRepositoryImpl implements ChannelRepository {
+
+  private final ChannelJpaRepository channelJpaRepository;
+
+  @Override
+  public Channel save(Channel channel) {
+    ChannelEntity saved = channelJpaRepository.save(toEntity(channel));
+    return toDomain(saved);
+  }
+
+  @Override
+  public List<Channel> findAllByUserId(UUID userId) {
+    return channelJpaRepository.findAllByUserIdAndDeletedAtIsNull(userId).stream()
+        .map(this::toDomain)
+        .toList();
+  }
+
+  @Override
+  public Optional<Channel> findById(UUID id) {
+    return channelJpaRepository.findById(id).map(this::toDomain);
+  }
+
+  private ChannelEntity toEntity(Channel channel) {
+    return new ChannelEntity(
+        channel.getId(),
+        channel.getUserId(),
+        channel.getType(),
+        channel.getName(),
+        channel.getConfig(),
+        channel.getCreatedAt(),
+        channel.getUpdatedAt(),
+        channel.getDeletedAt()
+    );
+  }
+
+  private Channel toDomain(ChannelEntity entity) {
+    return new Channel(
+        entity.getId(),
+        entity.getUserId(),
+        entity.getType(),
+        entity.getName(),
+        entity.getConfig(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt(),
+        entity.getDeletedAt()
+    );
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.nextdv.infrastructure.channel;
 
 import com.nextdv.domain.channel.Channel;
 import com.nextdv.domain.channel.ChannelRepository;
+import com.nextdv.domain.channel.ChannelType;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -36,7 +37,7 @@ public class ChannelRepositoryImpl implements ChannelRepository {
     return new ChannelEntity(
         channel.getId(),
         channel.getUserId(),
-        channel.getType(),
+        ChannelTypeEntity.valueOf(channel.getType().name()),
         channel.getName(),
         channel.getConfig(),
         channel.getCreatedAt(),
@@ -49,7 +50,7 @@ public class ChannelRepositoryImpl implements ChannelRepository {
     return new Channel(
         entity.getId(),
         entity.getUserId(),
-        entity.getType(),
+        ChannelType.valueOf(entity.getType().name()),
         entity.getName(),
         entity.getConfig(),
         entity.getCreatedAt(),

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelTypeEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelTypeEntity.java
@@ -1,0 +1,5 @@
+package com.nextdv.infrastructure.channel;
+
+public enum ChannelTypeEntity {
+  SLACK, DISCORD, APP, EMAIL
+}

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelTypeEntityTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelTypeEntityTest.java
@@ -1,0 +1,30 @@
+package com.nextdv.infrastructure.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nextdv.domain.channel.ChannelType;
+import org.junit.jupiter.api.Test;
+
+class ChannelTypeEntityTest {
+
+  @Test
+  void domain_타입을_infra_타입으로_변환한다() {
+    for (ChannelType domainType : ChannelType.values()) {
+      ChannelTypeEntity infraType = ChannelTypeEntity.valueOf(domainType.name());
+      assertThat(infraType.name()).isEqualTo(domainType.name());
+    }
+  }
+
+  @Test
+  void infra_타입을_domain_타입으로_변환한다() {
+    for (ChannelTypeEntity infraType : ChannelTypeEntity.values()) {
+      ChannelType domainType = ChannelType.valueOf(infraType.name());
+      assertThat(domainType.name()).isEqualTo(infraType.name());
+    }
+  }
+
+  @Test
+  void domain과_infra의_열거값이_동일하다() {
+    assertThat(ChannelTypeEntity.values()).hasSameSizeAs(ChannelType.values());
+  }
+}


### PR DESCRIPTION
## 요약
사용자가 알림 받을 채널을 등록/관리하는 도메인과 인프라 레이어 추가
Channel 도메인 모델, ChannelService(create/findAll/delete), ChannelRepository 인터페이스 추가
ChannelEntity(JSONB config, soft delete), ChannelJpaRepository, ChannelRepositoryImpl 추가

## 작업사항
- `ChannelType` ENUM(SLACK/DISCORD/APP/EMAIL) 추가
- `Channel` 도메인 모델, `ChannelRepository` 인터페이스, `ChannelService`(create/findAllByUserId/delete) 추가
- `ChannelEntity`(@Getter, JSONB config, soft delete), `ChannelJpaRepository`, `ChannelRepositoryImpl` 추가

## 기타

**채널 config JSONB 매핑**
채널 타입마다 설정값 구조가 다르므로(Slack은 웹훅 URL, Email은 주소 등) `Map<String, Object>`로 유연하게 관리. 엔티티에서 `@JdbcTypeCode(SqlTypes.JSON)` + `columnDefinition = "jsonb"`로 매핑.

**Soft delete 방식**
`deleted_at` 컬럼에 삭제 시각을 기록. `findAllByUserId`는 `deletedAt IS NULL` 조건으로 조회. 물리 삭제 없음.

**API 레이어 분리**
PR 크기 관리를 위해 Controller/Request/Response/Mapper는 별도 PR(`feat/channel-api`, #13)로 분리.