### PR TITLE
feat(healthcheck): HealthCheckLog 도메인 모델 추가

### DIFF
--- a/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLog.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLog.java
@@ -2,9 +2,11 @@ package com.nextdv.domain.healthcheck;
 
 import java.time.Instant;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class HealthCheckLog {
 
   private final UUID id;
@@ -12,13 +14,4 @@ public class HealthCheckLog {
   private final ServiceStatus status;
   private final long responseTimeMs;
   private final Instant checkedAt;
-
-  public HealthCheckLog(
-      UUID id, UUID platformId, ServiceStatus status, long responseTimeMs, Instant checkedAt) {
-    this.id = id;
-    this.platformId = platformId;
-    this.status = status;
-    this.responseTimeMs = responseTimeMs;
-    this.checkedAt = checkedAt;
-  }
 }

--- a/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLog.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLog.java
@@ -1,0 +1,24 @@
+package com.nextdv.domain.healthcheck;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class HealthCheckLog {
+
+  private final UUID id;
+  private final UUID platformId;
+  private final ServiceStatus status;
+  private final long responseTimeMs;
+  private final Instant checkedAt;
+
+  public HealthCheckLog(
+      UUID id, UUID platformId, ServiceStatus status, long responseTimeMs, Instant checkedAt) {
+    this.id = id;
+    this.platformId = platformId;
+    this.status = status;
+    this.responseTimeMs = responseTimeMs;
+    this.checkedAt = checkedAt;
+  }
+}

--- a/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLogRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLogRepository.java
@@ -1,0 +1,14 @@
+package com.nextdv.domain.healthcheck;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface HealthCheckLogRepository {
+
+  HealthCheckLog save(HealthCheckLog log);
+
+  List<HealthCheckLog> findAllByPlatformId(UUID platformId);
+
+  Optional<HealthCheckLog> findLatestByPlatformId(UUID platformId);
+}

--- a/domain/src/main/java/com/nextdv/domain/healthcheck/ServiceStatus.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/ServiceStatus.java
@@ -1,0 +1,5 @@
+package com.nextdv.domain.healthcheck;
+
+public enum ServiceStatus {
+  OPERATIONAL, DEGRADED, PARTIAL_OUTAGE, MAJOR_OUTAGE, UNKNOWN
+}

--- a/domain/src/main/java/com/nextdv/domain/healthcheck/ServiceStatus.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/ServiceStatus.java
@@ -1,5 +1,14 @@
 package com.nextdv.domain.healthcheck;
 
 public enum ServiceStatus {
-  OPERATIONAL, DEGRADED, PARTIAL_OUTAGE, MAJOR_OUTAGE, UNKNOWN
+  /** 정상 운영 중 */
+  OPERATIONAL,
+  /** 응답 지연 등 성능 저하 */
+  DEGRADED,
+  /** 일부 기능 장애 */
+  PARTIAL_OUTAGE,
+  /** 전면 장애 */
+  MAJOR_OUTAGE,
+  /** 상태 미확인 */
+  UNKNOWN
 }


### PR DESCRIPTION
## 도입
헬스체크 스케줄러 구현 전 도메인 레이어 선행 작업. 인프라(JPA 엔티티)와 스케줄러는 다음 PR에서 추가.

## 생성
- `ServiceStatus` — 플랫폼 상태 enum (OPERATIONAL / DEGRADED / PARTIAL_OUTAGE / MAJOR_OUTAGE / UNKNOWN)
- `HealthCheckLog` — 단건 헬스체크 결과 불변 모델 (platformId, status, responseTimeMs, checkedAt)
- `HealthCheckLogRepository` — 도메인 인터페이스 (save, findAllByPlatformId, findLatestByPlatformId)