### PR TITLE
feat(healthcheck): HealthCheckLog 인프라 레이어 추가

### DIFF
--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogEntity.java
@@ -1,0 +1,46 @@
+package com.nextdv.infrastructure.healthcheck;
+
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "health_check_logs")
+public class HealthCheckLogEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(name = "platform_id", nullable = false)
+  private UUID platformId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, columnDefinition = "service_status")
+  private ServiceStatus status;
+
+  @Column(name = "response_time_ms", nullable = false)
+  private long responseTimeMs;
+
+  @Column(name = "checked_at", nullable = false)
+  private Instant checkedAt;
+
+  protected HealthCheckLogEntity() {
+  }
+
+  public HealthCheckLogEntity(
+      UUID id, UUID platformId, ServiceStatus status, long responseTimeMs, Instant checkedAt) {
+    this.id = id;
+    this.platformId = platformId;
+    this.status = status;
+    this.responseTimeMs = responseTimeMs;
+    this.checkedAt = checkedAt;
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogEntity.java
@@ -26,10 +26,10 @@ public class HealthCheckLogEntity {
   @Column(nullable = false, columnDefinition = "service_status")
   private ServiceStatus status;
 
-  @Column(name = "response_time_ms", nullable = false)
+  @Column(name = "response_ms", nullable = false)
   private long responseTimeMs;
 
-  @Column(name = "checked_at", nullable = false)
+  @Column(name = "created_at", nullable = false)
   private Instant checkedAt;
 
   protected HealthCheckLogEntity() {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogEntity.java
@@ -1,6 +1,5 @@
 package com.nextdv.infrastructure.healthcheck;
 
-import com.nextdv.domain.healthcheck.ServiceStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -24,7 +23,7 @@ public class HealthCheckLogEntity {
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false, columnDefinition = "service_status")
-  private ServiceStatus status;
+  private ServiceStatusEntity status;
 
   @Column(name = "response_ms", nullable = false)
   private long responseTimeMs;
@@ -36,7 +35,8 @@ public class HealthCheckLogEntity {
   }
 
   public HealthCheckLogEntity(
-      UUID id, UUID platformId, ServiceStatus status, long responseTimeMs, Instant checkedAt) {
+      UUID id, UUID platformId, ServiceStatusEntity status, long responseTimeMs,
+      Instant checkedAt) {
     this.id = id;
     this.platformId = platformId;
     this.status = status;

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogEntity.java
@@ -9,8 +9,10 @@ import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Entity
 @Table(name = "health_check_logs")
 public class HealthCheckLogEntity {
@@ -30,9 +32,6 @@ public class HealthCheckLogEntity {
 
   @Column(name = "created_at", nullable = false)
   private Instant checkedAt;
-
-  protected HealthCheckLogEntity() {
-  }
 
   public HealthCheckLogEntity(
       UUID id, UUID platformId, ServiceStatusEntity status, long responseTimeMs,

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogJpaRepository.java
@@ -1,0 +1,13 @@
+package com.nextdv.infrastructure.healthcheck;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HealthCheckLogJpaRepository extends JpaRepository<HealthCheckLogEntity, UUID> {
+
+  List<HealthCheckLogEntity> findAllByPlatformId(UUID platformId);
+
+  Optional<HealthCheckLogEntity> findTopByPlatformIdOrderByCheckedAtDesc(UUID platformId);
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.nextdv.infrastructure.healthcheck;
+
+import com.nextdv.domain.healthcheck.HealthCheckLog;
+import com.nextdv.domain.healthcheck.HealthCheckLogRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class HealthCheckLogRepositoryImpl implements HealthCheckLogRepository {
+
+  private final HealthCheckLogJpaRepository jpaRepository;
+
+  @Override
+  public HealthCheckLog save(HealthCheckLog log) {
+    HealthCheckLogEntity entity = new HealthCheckLogEntity(
+        log.getId(), log.getPlatformId(), log.getStatus(),
+        log.getResponseTimeMs(), log.getCheckedAt()
+    );
+    return toDomain(jpaRepository.save(entity));
+  }
+
+  @Override
+  public List<HealthCheckLog> findAllByPlatformId(UUID platformId) {
+    return jpaRepository.findAllByPlatformId(platformId).stream().map(this::toDomain).toList();
+  }
+
+  @Override
+  public Optional<HealthCheckLog> findLatestByPlatformId(UUID platformId) {
+    return jpaRepository.findTopByPlatformIdOrderByCheckedAtDesc(platformId).map(this::toDomain);
+  }
+
+  private HealthCheckLog toDomain(HealthCheckLogEntity entity) {
+    return new HealthCheckLog(
+        entity.getId(),
+        entity.getPlatformId(),
+        entity.getStatus(),
+        entity.getResponseTimeMs(),
+        entity.getCheckedAt()
+    );
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.nextdv.infrastructure.healthcheck;
 
 import com.nextdv.domain.healthcheck.HealthCheckLog;
 import com.nextdv.domain.healthcheck.HealthCheckLogRepository;
+import com.nextdv.domain.healthcheck.ServiceStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -17,8 +18,11 @@ public class HealthCheckLogRepositoryImpl implements HealthCheckLogRepository {
   @Override
   public HealthCheckLog save(HealthCheckLog log) {
     HealthCheckLogEntity entity = new HealthCheckLogEntity(
-        log.getId(), log.getPlatformId(), log.getStatus(),
-        log.getResponseTimeMs(), log.getCheckedAt()
+        log.getId(),
+        log.getPlatformId(),
+        ServiceStatusEntity.valueOf(log.getStatus().name()),
+        log.getResponseTimeMs(),
+        log.getCheckedAt()
     );
     return toDomain(jpaRepository.save(entity));
   }
@@ -37,7 +41,7 @@ public class HealthCheckLogRepositoryImpl implements HealthCheckLogRepository {
     return new HealthCheckLog(
         entity.getId(),
         entity.getPlatformId(),
-        entity.getStatus(),
+        ServiceStatus.valueOf(entity.getStatus().name()),
         entity.getResponseTimeMs(),
         entity.getCheckedAt()
     );

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/ServiceStatusEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/ServiceStatusEntity.java
@@ -1,5 +1,14 @@
 package com.nextdv.infrastructure.healthcheck;
 
 public enum ServiceStatusEntity {
-  OPERATIONAL, DEGRADED, PARTIAL_OUTAGE, MAJOR_OUTAGE, UNKNOWN
+  /** 정상 운영 중 */
+  OPERATIONAL,
+  /** 응답 지연 등 성능 저하 */
+  DEGRADED,
+  /** 일부 기능 장애 */
+  PARTIAL_OUTAGE,
+  /** 전면 장애 */
+  MAJOR_OUTAGE,
+  /** 상태 미확인 */
+  UNKNOWN
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/ServiceStatusEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/ServiceStatusEntity.java
@@ -1,0 +1,5 @@
+package com.nextdv.infrastructure.healthcheck;
+
+public enum ServiceStatusEntity {
+  OPERATIONAL, DEGRADED, PARTIAL_OUTAGE, MAJOR_OUTAGE, UNKNOWN
+}


### PR DESCRIPTION
## 요약
HealthCheckLog 도메인(#14) 위에 JPA 인프라 레이어 추가. 스케줄러가 헬스체크 결과를 저장할 수 있는 구현체 마련.

## 작업사항
- `HealthCheckLogEntity` — health_check_logs 테이블 매핑, service_status PostgreSQL enum 적용
- `HealthCheckLogJpaRepository` — platformId 기준 조회, 최신 1건 조회 쿼리
- `HealthCheckLogRepositoryImpl` — 도메인 인터페이스 구현, Entity ↔ Domain 변환

## 기타