### PR TITLE
feat(healthcheck): 플랫폼 헬스체크 스케줄러 추가

### DIFF
--- a/infrastructure/build.gradle
+++ b/infrastructure/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework:spring-web'
     runtimeOnly    'org.postgresql:postgresql'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/SchedulingConfig.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/SchedulingConfig.java
@@ -1,0 +1,20 @@
+package com.nextdv.infrastructure;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+
+  @Bean
+  RestClient healthCheckRestClient() {
+    SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+    factory.setConnectTimeout(5000);
+    factory.setReadTimeout(10000);
+    return RestClient.builder().requestFactory(factory).build();
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
@@ -1,0 +1,71 @@
+package com.nextdv.infrastructure.healthcheck;
+
+import com.nextdv.domain.healthcheck.HealthCheckLog;
+import com.nextdv.domain.healthcheck.HealthCheckLogRepository;
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.Platform;
+import com.nextdv.domain.platform.PlatformService;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+public class HealthCheckPollService {
+
+  private final PlatformService platformService;
+  private final HealthCheckLogRepository healthCheckLogRepository;
+  private final RestClient healthCheckRestClient;
+
+  public void pollAll() {
+    platformService.findAll().forEach(this::poll);
+  }
+
+  private void poll(Platform platform) {
+    long startMs = System.currentTimeMillis();
+    ServiceStatus status;
+    long responseMs;
+    try {
+      ResponseEntity<Void> response = healthCheckRestClient
+          .get()
+          .uri(platform.getHealthCheckUrl())
+          .retrieve()
+          .onStatus(
+              HttpStatusCode::isError,
+              (req, res) -> {
+              }
+          )
+          .toBodilessEntity();
+      responseMs = System.currentTimeMillis() - startMs;
+      status = determineStatus(
+          response.getStatusCode().value(),
+          responseMs,
+          platform.getDegradedThresholdMs()
+      );
+    } catch (ResourceAccessException e) {
+      responseMs = System.currentTimeMillis() - startMs;
+      status = ServiceStatus.MAJOR_OUTAGE;
+    }
+
+    healthCheckLogRepository.save(
+        new HealthCheckLog(
+            UUID.randomUUID(), platform.getId(), status, responseMs, Instant.now()
+        )
+    );
+  }
+
+  private ServiceStatus determineStatus(int httpStatus, long responseMs, int degradedThresholdMs) {
+    if (httpStatus >= 500)
+      return ServiceStatus.MAJOR_OUTAGE;
+    if (httpStatus >= 400)
+      return ServiceStatus.PARTIAL_OUTAGE;
+    if (responseMs >= degradedThresholdMs)
+      return ServiceStatus.DEGRADED;
+    return ServiceStatus.OPERATIONAL;
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
@@ -59,7 +59,7 @@ public class HealthCheckPollService {
     );
   }
 
-  private ServiceStatus determineStatus(int httpStatus, long responseMs, int degradedThresholdMs) {
+  ServiceStatus determineStatus(int httpStatus, long responseMs, int degradedThresholdMs) {
     if (httpStatus >= 500)
       return ServiceStatus.MAJOR_OUTAGE;
     if (httpStatus >= 400)

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckScheduler.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckScheduler.java
@@ -1,0 +1,17 @@
+package com.nextdv.infrastructure.healthcheck;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HealthCheckScheduler {
+
+  private final HealthCheckPollService healthCheckPollService;
+
+  @Scheduled(fixedDelay = 60_000)
+  public void run() {
+    healthCheckPollService.pollAll();
+  }
+}

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollServiceTest.java
@@ -1,0 +1,51 @@
+package com.nextdv.infrastructure.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import org.junit.jupiter.api.Test;
+
+class HealthCheckPollServiceTest {
+
+  private final HealthCheckPollService service = new HealthCheckPollService(null, null, null);
+
+  @Test
+  void 응답이_2xx이고_임계값_미만이면_OPERATIONAL() {
+    ServiceStatus status = service.determineStatus(
+        200,
+        500,
+        1000
+    );
+    assertThat(status).isEqualTo(ServiceStatus.OPERATIONAL);
+  }
+
+  @Test
+  void 응답이_2xx이고_임계값_이상이면_DEGRADED() {
+    ServiceStatus status = service.determineStatus(
+        200,
+        1000,
+        1000
+    );
+    assertThat(status).isEqualTo(ServiceStatus.DEGRADED);
+  }
+
+  @Test
+  void 응답이_4xx이면_PARTIAL_OUTAGE() {
+    ServiceStatus status = service.determineStatus(
+        404,
+        100,
+        1000
+    );
+    assertThat(status).isEqualTo(ServiceStatus.PARTIAL_OUTAGE);
+  }
+
+  @Test
+  void 응답이_5xx이면_MAJOR_OUTAGE() {
+    ServiceStatus status = service.determineStatus(
+        500,
+        100,
+        1000
+    );
+    assertThat(status).isEqualTo(ServiceStatus.MAJOR_OUTAGE);
+  }
+}


### PR DESCRIPTION
## 요약
모든 활성 플랫폼을 60초마다 HTTP GET으로 폴링하여 `HealthCheckLog`를 저장하는 스케줄러 추가.

## 작업사항
- `SchedulingConfig`: `@EnableScheduling` 활성화 + `healthCheckRestClient` 빈 (connect 5s / read 10s timeout)
- `HealthCheckPollService`: 플랫폼별 HTTP 폴링, 응답시간·상태코드 기반 `ServiceStatus` 판단
  - HTTP 2xx + responseMs < degradedThresholdMs → `OPERATIONAL`
  - HTTP 2xx + responseMs ≥ degradedThresholdMs → `DEGRADED`
  - HTTP 4xx → `PARTIAL_OUTAGE`
  - HTTP 5xx → `MAJOR_OUTAGE`
  - 연결 실패 / 타임아웃 → `MAJOR_OUTAGE`
- `HealthCheckScheduler`: `@Scheduled(fixedDelay=60_000)` 로 `pollAll()` 호출
- `infrastructure/build.gradle`: `spring-web` 의존성 추가 (RestClient 사용)

## 기타
- base 브랜치: `feat/healthcheck-infra` (#15) 위에 스택
- 폴링 주기는 추후 `@Value`로 외부화 가능