### PR TITLE
feat(platform): 플랫폼 단건 조회 추가 (findById)

### DIFF
--- a/domain/src/main/java/com/nextdv/domain/platform/PlatformRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/PlatformRepository.java
@@ -1,8 +1,12 @@
 package com.nextdv.domain.platform;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface PlatformRepository {
 
   List<Platform> findAll(boolean activeOnly);
+
+  Optional<Platform> findById(UUID id);
 }

--- a/domain/src/main/java/com/nextdv/domain/platform/PlatformService.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/PlatformService.java
@@ -1,6 +1,8 @@
 package com.nextdv.domain.platform;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,5 +14,9 @@ public class PlatformService {
 
   public List<Platform> findAll() {
     return platformRepository.findAll(true);
+  }
+
+  public Optional<Platform> findById(UUID id) {
+    return platformRepository.findById(id);
   }
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.nextdv.infrastructure.platform;
 import com.nextdv.domain.platform.Platform;
 import com.nextdv.domain.platform.PlatformRepository;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -18,6 +20,11 @@ public class PlatformRepositoryImpl implements PlatformRepository {
         .filter(entity -> !activeOnly || entity.isActive())
         .map(this::toDomain)
         .toList();
+  }
+
+  @Override
+  public Optional<Platform> findById(UUID id) {
+    return platformJpaRepository.findById(id).map(this::toDomain);
   }
 
   private Platform toDomain(PlatformEntity entity) {

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/platform/PlatformServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/platform/PlatformServiceTest.java
@@ -6,6 +6,7 @@ import com.nextdv.domain.platform.Platform;
 import com.nextdv.domain.platform.PlatformService;
 import com.nextdv.domain.platform.ServiceCategory;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,5 +67,29 @@ class PlatformServiceTest {
             "GitHub",
             "AWS"
         );
+  }
+
+  @Test
+  void ID로_플랫폼을_단건_조회한다() {
+    UUID id = UUID.randomUUID();
+    jpaRepository.save(
+        new PlatformEntity(
+            id, "GitHub", ServiceCategory.DEVTOOL,
+            "https://api.github.com", 3000, 1000, null, true
+        )
+    );
+
+    Optional<Platform> result = platformService.findById(id);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().getId()).isEqualTo(id);
+    assertThat(result.get().getName()).isEqualTo("GitHub");
+  }
+
+  @Test
+  void 존재하지_않는_ID로_조회하면_빈_Optional을_반환한다() {
+    Optional<Platform> result = platformService.findById(UUID.randomUUID());
+
+    assertThat(result).isEmpty();
   }
 }


### PR DESCRIPTION
## 요약
플랫폼 ID로 단건 조회하는 메서드 추가.

## 작업사항
- `PlatformRepository`: `findById(UUID)` 인터페이스 추가
- `PlatformService`: `findById(UUID)` 서비스 메서드 추가
- `PlatformRepositoryImpl`: JpaRepository `findById` 위임 구현

## 기타
- base: main