### PR TITLE
security: 컨테이너 non-root 실행 및 resource limits 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,6 @@ FROM eclipse-temurin:25-jre
 WORKDIR /app
 COPY --from=build /app/api/build/libs/ ./libs/
 RUN find ./libs -name "*.jar" ! -name "*-plain.jar" -exec cp {} app.jar \; && rm -rf ./libs
+RUN useradd -r -u 10001 appuser && chown appuser:appuser /app/app.jar
+USER 10001
 ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ FROM eclipse-temurin:25-jre
 WORKDIR /app
 COPY --from=build /app/api/build/libs/ ./libs/
 RUN find ./libs -name "*.jar" ! -name "*-plain.jar" -exec cp {} app.jar \; && rm -rf ./libs
-RUN useradd -r -u 10001 appuser && chown appuser:appuser /app/app.jar
+RUN useradd -r -u 10001 appuser && chown appuser:appuser app.jar
 USER 10001
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/nextdv}
     username: ${DB_USERNAME:nextdv}
-    password: ${DB_PASSWORD:nextdv}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       POSTGRES_DB: nextdv
       POSTGRES_USER: nextdv
-      POSTGRES_PASSWORD: nextdv
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/k3s/deployment.yaml
+++ b/k3s/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 10001
+        runAsGroup: 10001
         fsGroup: 10001
         seccompProfile:
           type: RuntimeDefault

--- a/k3s/deployment.yaml
+++ b/k3s/deployment.yaml
@@ -15,6 +15,12 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: heartbeat
           image: ghcr.io/nextdv/heartbeat-server:latest
@@ -24,6 +30,18 @@ spec:
           envFrom:
             - secretRef:
                 name: heartbeat-secret
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: ["ALL"]
           readinessProbe:
             tcpSocket:
               port: 8080


### PR DESCRIPTION
## 개요
보안 이슈 #42, #44 처리.

## 변경 사항
- **Dockerfile**: UID 10001 `appuser` 생성, root가 아닌 일반 유저로 실행
- **deployment.yaml**: Pod/Container securityContext 추가
  - `runAsNonRoot: true`, `runAsUser: 10001`
  - `allowPrivilegeEscalation: false`
  - `capabilities: drop ALL`
  - `seccompProfile: RuntimeDefault`
- **deployment.yaml**: resource limits/requests 추가
  - requests: cpu 250m / memory 512Mi
  - limits: cpu 1 / memory 1Gi
- **ingress.yaml**: Cloudflare Flexible 방식 적용 (web 엔드포인트)

## 관련 이슈
closes #42, closes #44