### PR TITLE
feat(healthcheck): service_current_status UPSERT 구현

### DIFF
--- a/domain/src/main/java/com/nextdv/domain/healthcheck/ServiceCurrentStatus.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/ServiceCurrentStatus.java
@@ -1,0 +1,8 @@
+package com.nextdv.domain.healthcheck;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ServiceCurrentStatus(
+    UUID platformId, ServiceStatus status, long responseTimeMs, Instant lastCheckedAt) {
+}

--- a/domain/src/main/java/com/nextdv/domain/healthcheck/ServiceCurrentStatusRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/ServiceCurrentStatusRepository.java
@@ -1,0 +1,11 @@
+package com.nextdv.domain.healthcheck;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ServiceCurrentStatusRepository {
+
+  void save(ServiceCurrentStatus status);
+
+  Optional<ServiceCurrentStatus> findByPlatformId(UUID platformId);
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/ServiceCurrentStatusEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/ServiceCurrentStatusEntity.java
@@ -1,0 +1,47 @@
+package com.nextdv.infrastructure.healthcheck;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Entity
+@Table(name = "service_current_status")
+public class ServiceCurrentStatusEntity {
+
+  @Id
+  @Column(name = "platform_id", nullable = false)
+  private UUID platformId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ServiceStatusEntity status;
+
+  @Column(name = "response_ms", nullable = false)
+  private long responseMs;
+
+  @Column(name = "last_checked_at", nullable = false)
+  private Instant lastCheckedAt;
+
+  public ServiceCurrentStatusEntity(
+      UUID platformId, ServiceStatusEntity status, long responseMs, Instant lastCheckedAt) {
+    this.platformId = platformId;
+    this.status = status;
+    this.responseMs = responseMs;
+    this.lastCheckedAt = lastCheckedAt;
+  }
+
+  public void update(ServiceStatusEntity status, long responseMs, Instant lastCheckedAt) {
+    this.status = status;
+    this.responseMs = responseMs;
+    this.lastCheckedAt = lastCheckedAt;
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/ServiceCurrentStatusJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/ServiceCurrentStatusJpaRepository.java
@@ -1,0 +1,9 @@
+package com.nextdv.infrastructure.healthcheck;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface ServiceCurrentStatusJpaRepository
+    extends
+      JpaRepository<ServiceCurrentStatusEntity, UUID> {
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/ServiceCurrentStatusRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/ServiceCurrentStatusRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.nextdv.infrastructure.healthcheck;
+
+import com.nextdv.domain.healthcheck.ServiceCurrentStatus;
+import com.nextdv.domain.healthcheck.ServiceCurrentStatusRepository;
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ServiceCurrentStatusRepositoryImpl implements ServiceCurrentStatusRepository {
+
+  private final ServiceCurrentStatusJpaRepository jpaRepository;
+
+  @Override
+  public void save(ServiceCurrentStatus status) {
+    ServiceStatusEntity statusEntity = ServiceStatusEntity.valueOf(status.status().name());
+    jpaRepository
+        .findById(status.platformId())
+        .ifPresentOrElse(
+            entity -> entity.update(
+                statusEntity,
+                status.responseTimeMs(),
+                status.lastCheckedAt()
+            ),
+            () -> jpaRepository.save(
+                new ServiceCurrentStatusEntity(
+                    status.platformId(),
+                    statusEntity,
+                    status.responseTimeMs(),
+                    status.lastCheckedAt()
+                )
+            )
+        );
+  }
+
+  @Override
+  public Optional<ServiceCurrentStatus> findByPlatformId(UUID platformId) {
+    return jpaRepository.findById(platformId).map(this::toDomain);
+  }
+
+  private ServiceCurrentStatus toDomain(ServiceCurrentStatusEntity entity) {
+    return new ServiceCurrentStatus(
+        entity.getPlatformId(),
+        ServiceStatus.valueOf(entity.getStatus().name()),
+        entity.getResponseMs(),
+        entity.getLastCheckedAt()
+    );
+  }
+}


### PR DESCRIPTION
## 개요
이슈 #33 구현. 플랫폼별 현재 상태를 별도 테이블에 UPSERT로 관리.

## 변경 사항

### domain
- `ServiceCurrentStatus` record (platformId, status, responseTimeMs, lastCheckedAt)
- `ServiceCurrentStatusRepository` 인터페이스

### infrastructure
- `ServiceCurrentStatusEntity` — `service_current_status` 테이블, PK: platform_id
- `ServiceCurrentStatusJpaRepository` — JpaRepository 확장
- `ServiceCurrentStatusRepositoryImpl` — find-then-save UPSERT 패턴

## 테스트
- 최초 저장 ✅
- 동일 platformId 업데이트 ✅
- 존재하지 않는 platformId 조회 시 빈값 반환 ✅

## 참고
스케줄러(HealthCheckPollService) 연동은 PR #16 머지 후 별도 커밋으로 진행.

closes #33