### PR TITLE
feat: UUID v7 생성 유틸리티 도메인 공통화 (#32)

### DIFF
--- a/config/checkstyle/import-control.xml
+++ b/config/checkstyle/import-control.xml
@@ -9,6 +9,7 @@
     <allow pkg="java"/>
     <allow pkg="lombok"/>
     <allow pkg="org.springframework"/>
+    <allow pkg="com.fasterxml.uuid"/>
     <allow pkg="com.nextdv.domain"/>
     <disallow pkg="com.nextdv.api"/>
     <disallow pkg="com.nextdv.infrastructure"/>

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -1,3 +1,8 @@
 dependencies {
     implementation 'org.springframework:spring-context'
+    implementation 'com.fasterxml.uuid:java-uuid-generator:5.2.0'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/domain/src/main/java/com/nextdv/domain/common/UuidV7.java
+++ b/domain/src/main/java/com/nextdv/domain/common/UuidV7.java
@@ -1,0 +1,17 @@
+package com.nextdv.domain.common;
+
+import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
+import java.util.UUID;
+
+public final class UuidV7 {
+
+  private static final TimeBasedEpochGenerator GENERATOR = Generators.timeBasedEpochGenerator();
+
+  private UuidV7() {
+  }
+
+  public static UUID generate() {
+    return GENERATOR.generate();
+  }
+}

--- a/domain/src/test/java/com/nextdv/domain/common/UuidV7Test.java
+++ b/domain/src/test/java/com/nextdv/domain/common/UuidV7Test.java
@@ -1,0 +1,39 @@
+package com.nextdv.domain.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class UuidV7Test {
+
+  @Test
+  void UUID_v7을_생성한다() {
+    UUID uuid = UuidV7.generate();
+
+    assertThat(uuid).isNotNull();
+  }
+
+  @Test
+  void 생성된_UUID는_버전7이다() {
+    UUID uuid = UuidV7.generate();
+
+    assertThat(uuid.version()).isEqualTo(7);
+  }
+
+  @Test
+  void 연속_생성된_UUID는_시간순으로_정렬된다() {
+    UUID first = UuidV7.generate();
+    UUID second = UuidV7.generate();
+
+    assertThat(first.toString().compareTo(second.toString())).isLessThanOrEqualTo(0);
+  }
+
+  @Test
+  void 생성된_UUID는_매번_다르다() {
+    UUID first = UuidV7.generate();
+    UUID second = UuidV7.generate();
+
+    assertThat(first).isNotEqualTo(second);
+  }
+}


### PR DESCRIPTION
## 개요

도메인 레이어에 UUID v7 생성 유틸리티를 추가한다.

Closes #32

## 변경 사항

- `domain/common/UuidV7` — 정적 유틸 클래스, `generate()` 메서드 제공
- `domain/build.gradle` — `java-uuid-generator:5.2.0` 의존성 추가
- `config/checkstyle/import-control.xml` — domain 레이어에서 `com.fasterxml.uuid` 허용
- `UuidV7Test` — UUID 생성, 버전 검증, 단조 순서, 유일성 4개 테스트

## 설계 결정

- 인터페이스 없이 정적 유틸로 구현 (순수 값 생성, 외부 상태·I/O 없음, mock 불필요)
- `TimeBasedEpochGenerator` 를 static final로 유지 → 동일 프로세스 내 단조 증가 보장
- ADR-003 참조

## 테스트 결과

```
UuidV7Test > UUID_v7을_생성한다() PASSED
UuidV7Test > 생성된_UUID는_버전7이다() PASSED
UuidV7Test > 연속_생성된_UUID는_시간순으로_정렬된다() PASSED
UuidV7Test > 생성된_UUID는_매번_다르다() PASSED
```