### PR TITLE
test(channel): 미사용 mockito 의존성 제거 및 소프트 삭제 필터링 테스트 추가

### DIFF
--- a/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelServiceTest.java
@@ -97,6 +97,29 @@ class ChannelServiceTest {
   }
 
   @Test
+  void 삭제된_채널은_목록_조회에서_제외된다() {
+    UUID userId = UUID.randomUUID();
+    Channel active = channelService.create(
+        userId,
+        ChannelType.SLACK,
+        "활성 채널",
+        Map.of()
+    );
+    Channel deleted = channelService.create(
+        userId,
+        ChannelType.DISCORD,
+        "삭제된 채널",
+        Map.of()
+    );
+    channelService.delete(deleted.getId());
+
+    List<Channel> result = channelService.findAllByUserId(userId);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getId()).isEqualTo(active.getId());
+  }
+
+  @Test
   void 존재하지_않는_채널을_삭제하면_예외가_발생한다() {
     UUID channelId = UUID.randomUUID();
 


### PR DESCRIPTION
## 개요

PR #21 코드 리뷰(Opus) 결과 발견된 2가지 개선사항을 반영한다.

## 변경 사항

- `domain/build.gradle` — 미사용 `mockito-junit-jupiter` 의존성 제거 (Testcontainers로 교체 후 참조 없음)
- `ChannelServiceTest` — 소프트 삭제된 채널이 `findAllByUserId` 결과에서 제외되는지 검증하는 케이스 추가

## 선행 PR

#21 머지 후 base를 main으로 재타겟 예정