### PR TITLE
feat: incidents 자동 감지/복구 및 조회 API 구현

### DIFF
--- a/api/src/main/java/com/nextdv/api/incident/IncidentController.java
+++ b/api/src/main/java/com/nextdv/api/incident/IncidentController.java
@@ -1,0 +1,36 @@
+package com.nextdv.api.incident;
+
+import com.nextdv.api.common.ApiResponse;
+import com.nextdv.domain.incident.Incident;
+import com.nextdv.domain.incident.IncidentRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/incidents")
+@RequiredArgsConstructor
+public class IncidentController {
+
+  private final IncidentRepository incidentRepository;
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<IncidentResponse>>> list() {
+    List<Incident> incidents = incidentRepository.findAll();
+    return ResponseEntity.ok(ApiResponse.ok(IncidentMapper.toResponseList(incidents)));
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<ApiResponse<IncidentResponse>> findById(@PathVariable UUID id) {
+    Incident incident = incidentRepository
+        .findById(id)
+        .orElseThrow(() -> new NoSuchElementException("인시던트를 찾을 수 없습니다."));
+    return ResponseEntity.ok(ApiResponse.ok(IncidentMapper.toResponse(incident)));
+  }
+}

--- a/api/src/main/java/com/nextdv/api/incident/IncidentMapper.java
+++ b/api/src/main/java/com/nextdv/api/incident/IncidentMapper.java
@@ -1,0 +1,27 @@
+package com.nextdv.api.incident;
+
+import com.nextdv.domain.incident.Incident;
+import java.util.List;
+
+public class IncidentMapper {
+
+  private IncidentMapper() {
+  }
+
+  public static IncidentResponse toResponse(Incident incident) {
+    return new IncidentResponse(
+        incident.getId(),
+        incident.getPlatformId(),
+        incident.getImpact(),
+        incident.getStatus(),
+        incident.getStartedAt(),
+        incident.getResolvedAt()
+    );
+  }
+
+  public static List<IncidentResponse> toResponseList(List<Incident> incidents) {
+    return incidents.stream()
+        .map(IncidentMapper::toResponse)
+        .toList();
+  }
+}

--- a/api/src/main/java/com/nextdv/api/incident/IncidentResponse.java
+++ b/api/src/main/java/com/nextdv/api/incident/IncidentResponse.java
@@ -1,0 +1,20 @@
+package com.nextdv.api.incident;
+
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.incident.IncidentStatus;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class IncidentResponse {
+
+  private final UUID id;
+  private final UUID platformId;
+  private final ServiceStatus impact;
+  private final IncidentStatus status;
+  private final Instant startedAt;
+  private final Instant resolvedAt;
+}

--- a/domain/src/main/java/com/nextdv/domain/incident/Incident.java
+++ b/domain/src/main/java/com/nextdv/domain/incident/Incident.java
@@ -1,0 +1,19 @@
+package com.nextdv.domain.incident;
+
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Incident {
+
+  private final UUID id;
+  private final UUID platformId;
+  private final ServiceStatus impact;
+  private final IncidentStatus status;
+  private final Instant startedAt;
+  private final Instant resolvedAt;
+}

--- a/domain/src/main/java/com/nextdv/domain/incident/IncidentRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/incident/IncidentRepository.java
@@ -1,0 +1,16 @@
+package com.nextdv.domain.incident;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface IncidentRepository {
+
+  Incident save(Incident incident);
+
+  Optional<Incident> findOpenByPlatformId(UUID platformId);
+
+  List<Incident> findAll();
+
+  Optional<Incident> findById(UUID id);
+}

--- a/domain/src/main/java/com/nextdv/domain/incident/IncidentStatus.java
+++ b/domain/src/main/java/com/nextdv/domain/incident/IncidentStatus.java
@@ -1,0 +1,5 @@
+package com.nextdv.domain.incident;
+
+public enum IncidentStatus {
+  OPEN, RESOLVED
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
@@ -1,8 +1,12 @@
 package com.nextdv.infrastructure.healthcheck;
 
+import com.nextdv.domain.common.UuidV7;
 import com.nextdv.domain.healthcheck.HealthCheckLog;
 import com.nextdv.domain.healthcheck.HealthCheckLogRepository;
 import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.incident.Incident;
+import com.nextdv.domain.incident.IncidentRepository;
+import com.nextdv.domain.incident.IncidentStatus;
 import com.nextdv.domain.platform.Platform;
 import com.nextdv.domain.platform.PlatformService;
 import java.time.Instant;
@@ -21,6 +25,7 @@ public class HealthCheckPollService {
   private final PlatformService platformService;
   private final HealthCheckLogRepository healthCheckLogRepository;
   private final RestClient healthCheckRestClient;
+  private final IncidentRepository incidentRepository;
 
   public void pollAll() {
     platformService.findAll().forEach(this::poll);
@@ -57,6 +62,35 @@ public class HealthCheckPollService {
             UUID.randomUUID(), platform.getId(), status, responseMs, Instant.now()
         )
     );
+
+    handleIncident(
+        platform.getId(),
+        status
+    );
+  }
+
+  private void handleIncident(UUID platformId, ServiceStatus status) {
+    if (status == ServiceStatus.PARTIAL_OUTAGE || status == ServiceStatus.MAJOR_OUTAGE) {
+      incidentRepository.findOpenByPlatformId(platformId).ifPresentOrElse(
+          existing -> {
+          },
+          () -> incidentRepository.save(
+              new Incident(
+                  UuidV7.generate(), platformId, status, IncidentStatus.OPEN,
+                  Instant.now(), null
+              )
+          )
+      );
+    } else {
+      incidentRepository.findOpenByPlatformId(platformId).ifPresent(
+          open -> incidentRepository.save(
+              new Incident(
+                  open.getId(), open.getPlatformId(), open.getImpact(),
+                  IncidentStatus.RESOLVED, open.getStartedAt(), Instant.now()
+              )
+          )
+      );
+    }
   }
 
   ServiceStatus determineStatus(int httpStatus, long responseMs, int degradedThresholdMs) {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/incident/IncidentEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/incident/IncidentEntity.java
@@ -1,0 +1,60 @@
+package com.nextdv.infrastructure.incident;
+
+import com.nextdv.infrastructure.healthcheck.ServiceStatusEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Entity
+@Table(name = "incidents")
+public class IncidentEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(name = "platform_id", nullable = false)
+  private UUID platformId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ServiceStatusEntity impact;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private IncidentStatusEntity status;
+
+  @Column(name = "started_at", nullable = false)
+  private Instant startedAt;
+
+  @Column(name = "resolved_at")
+  private Instant resolvedAt;
+
+  public IncidentEntity(
+      UUID id,
+      UUID platformId,
+      ServiceStatusEntity impact,
+      IncidentStatusEntity status,
+      Instant startedAt,
+      Instant resolvedAt) {
+    this.id = id;
+    this.platformId = platformId;
+    this.impact = impact;
+    this.status = status;
+    this.startedAt = startedAt;
+    this.resolvedAt = resolvedAt;
+  }
+
+  public void update(IncidentStatusEntity status, Instant resolvedAt) {
+    this.status = status;
+    this.resolvedAt = resolvedAt;
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/incident/IncidentJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/incident/IncidentJpaRepository.java
@@ -1,0 +1,13 @@
+package com.nextdv.infrastructure.incident;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface IncidentJpaRepository extends JpaRepository<IncidentEntity, UUID> {
+
+  Optional<IncidentEntity> findByPlatformIdAndStatus(UUID platformId, IncidentStatusEntity status);
+
+  List<IncidentEntity> findAllByOrderByStartedAtDesc();
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/incident/IncidentRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/incident/IncidentRepositoryImpl.java
@@ -1,0 +1,76 @@
+package com.nextdv.infrastructure.incident;
+
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.incident.Incident;
+import com.nextdv.domain.incident.IncidentRepository;
+import com.nextdv.domain.incident.IncidentStatus;
+import com.nextdv.infrastructure.healthcheck.ServiceStatusEntity;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class IncidentRepositoryImpl implements IncidentRepository {
+
+  private final IncidentJpaRepository jpaRepository;
+
+  @Override
+  public Incident save(Incident incident) {
+    IncidentStatusEntity statusEntity = IncidentStatusEntity.valueOf(incident.getStatus().name());
+    ServiceStatusEntity impactEntity = ServiceStatusEntity.valueOf(incident.getImpact().name());
+
+    jpaRepository.findById(incident.getId()).ifPresentOrElse(
+        entity -> entity.update(
+            statusEntity,
+            incident.getResolvedAt()
+        ),
+        () -> jpaRepository.save(
+            new IncidentEntity(
+                incident.getId(),
+                incident.getPlatformId(),
+                impactEntity,
+                statusEntity,
+                incident.getStartedAt(),
+                incident.getResolvedAt()
+            )
+        )
+    );
+    return incident;
+  }
+
+  @Override
+  public Optional<Incident> findOpenByPlatformId(UUID platformId) {
+    return jpaRepository
+        .findByPlatformIdAndStatus(
+            platformId,
+            IncidentStatusEntity.OPEN
+        )
+        .map(this::toDomain);
+  }
+
+  @Override
+  public List<Incident> findAll() {
+    return jpaRepository.findAllByOrderByStartedAtDesc().stream()
+        .map(this::toDomain)
+        .toList();
+  }
+
+  @Override
+  public Optional<Incident> findById(UUID id) {
+    return jpaRepository.findById(id).map(this::toDomain);
+  }
+
+  private Incident toDomain(IncidentEntity entity) {
+    return new Incident(
+        entity.getId(),
+        entity.getPlatformId(),
+        ServiceStatus.valueOf(entity.getImpact().name()),
+        IncidentStatus.valueOf(entity.getStatus().name()),
+        entity.getStartedAt(),
+        entity.getResolvedAt()
+    );
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/incident/IncidentStatusEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/incident/IncidentStatusEntity.java
@@ -1,0 +1,5 @@
+package com.nextdv.infrastructure.incident;
+
+public enum IncidentStatusEntity {
+  OPEN, RESOLVED
+}

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class HealthCheckPollServiceTest {
 
-  private final HealthCheckPollService service = new HealthCheckPollService(null, null, null);
+  private final HealthCheckPollService service = new HealthCheckPollService(null, null, null, null);
 
   @Test
   void 응답이_2xx이고_임계값_미만이면_OPERATIONAL() {

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/incident/IncidentRepositoryTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/incident/IncidentRepositoryTest.java
@@ -1,0 +1,114 @@
+package com.nextdv.infrastructure.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nextdv.domain.common.UuidV7;
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.incident.Incident;
+import com.nextdv.domain.incident.IncidentRepository;
+import com.nextdv.domain.incident.IncidentStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import(IncidentRepositoryImpl.class)
+@Testcontainers
+class IncidentRepositoryTest {
+
+  @Container
+  @ServiceConnection
+  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+  @Autowired
+  private IncidentRepository incidentRepository;
+
+  @Test
+  void 에러_상태에서_Incident가_OPEN으로_저장된다() {
+    UUID platformId = UUID.randomUUID();
+    Incident incident = new Incident(
+        UuidV7.generate(), platformId, ServiceStatus.MAJOR_OUTAGE,
+        IncidentStatus.OPEN, Instant.now(), null
+    );
+
+    incidentRepository.save(incident);
+
+    Optional<Incident> found = incidentRepository.findOpenByPlatformId(platformId);
+    assertThat(found).isPresent();
+    assertThat(found.get().getStatus()).isEqualTo(IncidentStatus.OPEN);
+    assertThat(found.get().getImpact()).isEqualTo(ServiceStatus.MAJOR_OUTAGE);
+    assertThat(found.get().getResolvedAt()).isNull();
+  }
+
+  @Test
+  void 복구_시_RESOLVED로_업데이트된다() {
+    UUID platformId = UUID.randomUUID();
+    UUID id = UuidV7.generate();
+    Instant startedAt = Instant.now();
+    incidentRepository.save(
+        new Incident(
+            id, platformId, ServiceStatus.PARTIAL_OUTAGE,
+            IncidentStatus.OPEN, startedAt, null
+        )
+    );
+
+    Incident resolved = new Incident(
+        id, platformId, ServiceStatus.PARTIAL_OUTAGE,
+        IncidentStatus.RESOLVED, startedAt, Instant.now()
+    );
+    incidentRepository.save(resolved);
+
+    Optional<Incident> open = incidentRepository.findOpenByPlatformId(platformId);
+    assertThat(open).isEmpty();
+  }
+
+  @Test
+  void 전체_인시던트를_최신순으로_조회한다() {
+    incidentRepository.save(
+        new Incident(
+            UuidV7.generate(), UUID.randomUUID(), ServiceStatus.MAJOR_OUTAGE,
+            IncidentStatus.RESOLVED, Instant.now().minusSeconds(120), Instant.now()
+        )
+    );
+    incidentRepository.save(
+        new Incident(
+            UuidV7.generate(), UUID.randomUUID(), ServiceStatus.PARTIAL_OUTAGE,
+            IncidentStatus.OPEN, Instant.now(), null
+        )
+    );
+
+    List<Incident> all = incidentRepository.findAll();
+
+    assertThat(all).hasSize(2);
+    assertThat(all.get(0).getStatus()).isEqualTo(IncidentStatus.OPEN);
+  }
+
+  @Test
+  void ID로_단건_조회한다() {
+    UUID id = UuidV7.generate();
+    UUID platformId = UUID.randomUUID();
+    incidentRepository.save(
+        new Incident(
+            id, platformId, ServiceStatus.MAJOR_OUTAGE,
+            IncidentStatus.OPEN, Instant.now(), null
+        )
+    );
+
+    Optional<Incident> found = incidentRepository.findById(id);
+
+    assertThat(found).isPresent();
+    assertThat(found.get().getPlatformId()).isEqualTo(platformId);
+  }
+}


### PR DESCRIPTION
## 개요

헬스체크 스케줄러가 플랫폼을 폴링할 때 PARTIAL_OUTAGE/MAJOR_OUTAGE 상태를 감지하면 Incident를 자동 생성하고, 정상으로 회복되면 자동으로 RESOLVED 처리합니다.

## 주요 변경사항

- `Incident` 도메인 모델 및 `IncidentRepository` 인터페이스 추가 (domain)
- `IncidentEntity`, `IncidentRepositoryImpl` 구현 (infrastructure)
- `HealthCheckPollService.poll()` 내 `handleIncident()` 메서드로 자동 감지/복구 로직 추가
- `GET /incidents`, `GET /incidents/{id}` API 추가 (api)
- `IncidentRepositoryTest` — Testcontainers 통합 테스트 4개

## 동작 방식

- **OPEN**: PARTIAL_OUTAGE 또는 MAJOR_OUTAGE 감지 시, 해당 플랫폼의 열린 Incident가 없으면 새로 생성
- **RESOLVED**: OPERATIONAL 또는 DEGRADED 복구 시, 열린 Incident가 있으면 resolvedAt 기록 후 RESOLVED 전환
- 중복 생성 없음 — 이미 OPEN 상태면 무시

## DB 마이그레이션 (수동 실행 필요)

```sql
CREATE TABLE incidents (
  id UUID PRIMARY KEY,
  platform_id UUID NOT NULL,
  impact VARCHAR(50) NOT NULL,
  status VARCHAR(20) NOT NULL,
  started_at TIMESTAMPTZ NOT NULL,
  resolved_at TIMESTAMPTZ
);
```

Closes #36