### PR TITLE
feat: expected_status_code 컬럼 추가 및 헬스체크 판정 로직 개선

### DIFF
--- a/domain/src/main/java/com/nextdv/domain/platform/Platform.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/Platform.java
@@ -14,6 +14,7 @@ public class Platform {
   private final int degradedThresholdMs;
   private final String iconUrl;
   private final boolean active;
+  private final int expectedStatusCode;
 
   public Platform(
       UUID id,
@@ -23,7 +24,8 @@ public class Platform {
       int timeoutMs,
       int degradedThresholdMs,
       String iconUrl,
-      boolean active) {
+      boolean active,
+      int expectedStatusCode) {
     this.id = id;
     this.name = name;
     this.category = category;
@@ -32,6 +34,7 @@ public class Platform {
     this.degradedThresholdMs = degradedThresholdMs;
     this.iconUrl = iconUrl;
     this.active = active;
+    this.expectedStatusCode = expectedStatusCode;
   }
 
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
@@ -45,7 +45,8 @@ public class HealthCheckPollService {
       status = determineStatus(
           response.getStatusCode().value(),
           responseMs,
-          platform.getDegradedThresholdMs()
+          platform.getDegradedThresholdMs(),
+          platform.getExpectedStatusCode()
       );
     } catch (ResourceAccessException e) {
       responseMs = System.currentTimeMillis() - startMs;
@@ -59,13 +60,17 @@ public class HealthCheckPollService {
     );
   }
 
-  ServiceStatus determineStatus(int httpStatus, long responseMs, int degradedThresholdMs) {
-    if (httpStatus >= 500)
-      return ServiceStatus.MAJOR_OUTAGE;
-    if (httpStatus >= 400)
+  ServiceStatus determineStatus(
+      int httpStatus, long responseMs, int degradedThresholdMs, int expectedStatusCode) {
+    if (httpStatus != expectedStatusCode) {
+      if (httpStatus >= 500) {
+        return ServiceStatus.MAJOR_OUTAGE;
+      }
       return ServiceStatus.PARTIAL_OUTAGE;
-    if (responseMs >= degradedThresholdMs)
+    }
+    if (responseMs >= degradedThresholdMs) {
       return ServiceStatus.DEGRADED;
+    }
     return ServiceStatus.OPERATIONAL;
   }
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformEntity.java
@@ -40,6 +40,9 @@ public class PlatformEntity {
   @Column(name = "is_active", nullable = false)
   private boolean isActive;
 
+  @Column(name = "expected_status_code", nullable = false)
+  private int expectedStatusCode;
+
   protected PlatformEntity() {
   }
 
@@ -51,7 +54,8 @@ public class PlatformEntity {
       int timeoutMs,
       int degradedThresholdMs,
       String iconUrl,
-      boolean isActive) {
+      boolean isActive,
+      int expectedStatusCode) {
     this.id = id;
     this.name = name;
     this.category = category;
@@ -60,6 +64,7 @@ public class PlatformEntity {
     this.degradedThresholdMs = degradedThresholdMs;
     this.iconUrl = iconUrl;
     this.isActive = isActive;
+    this.expectedStatusCode = expectedStatusCode;
   }
 
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformRepositoryImpl.java
@@ -36,7 +36,8 @@ public class PlatformRepositoryImpl implements PlatformRepository {
         entity.getTimeoutMs(),
         entity.getDegradedThresholdMs(),
         entity.getIconUrl(),
-        entity.isActive()
+        entity.isActive(),
+        entity.getExpectedStatusCode()
     );
   }
 

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollServiceTest.java
@@ -14,7 +14,8 @@ class HealthCheckPollServiceTest {
     ServiceStatus status = service.determineStatus(
         200,
         500,
-        1000
+        1000,
+        200
     );
     assertThat(status).isEqualTo(ServiceStatus.OPERATIONAL);
   }
@@ -24,7 +25,8 @@ class HealthCheckPollServiceTest {
     ServiceStatus status = service.determineStatus(
         200,
         1000,
-        1000
+        1000,
+        200
     );
     assertThat(status).isEqualTo(ServiceStatus.DEGRADED);
   }
@@ -34,7 +36,8 @@ class HealthCheckPollServiceTest {
     ServiceStatus status = service.determineStatus(
         404,
         100,
-        1000
+        1000,
+        200
     );
     assertThat(status).isEqualTo(ServiceStatus.PARTIAL_OUTAGE);
   }
@@ -44,7 +47,41 @@ class HealthCheckPollServiceTest {
     ServiceStatus status = service.determineStatus(
         500,
         100,
-        1000
+        1000,
+        200
+    );
+    assertThat(status).isEqualTo(ServiceStatus.MAJOR_OUTAGE);
+  }
+
+  @Test
+  void 기대코드가_401이고_실제도_401이면_OPERATIONAL() {
+    ServiceStatus status = service.determineStatus(
+        401,
+        500,
+        1000,
+        401
+    );
+    assertThat(status).isEqualTo(ServiceStatus.OPERATIONAL);
+  }
+
+  @Test
+  void 기대코드가_401인데_실제가_200이면_PARTIAL_OUTAGE() {
+    ServiceStatus status = service.determineStatus(
+        200,
+        500,
+        1000,
+        401
+    );
+    assertThat(status).isEqualTo(ServiceStatus.PARTIAL_OUTAGE);
+  }
+
+  @Test
+  void 기대코드가_401인데_실제가_500이면_MAJOR_OUTAGE() {
+    ServiceStatus status = service.determineStatus(
+        500,
+        500,
+        1000,
+        401
     );
     assertThat(status).isEqualTo(ServiceStatus.MAJOR_OUTAGE);
   }

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/platform/PlatformServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/platform/PlatformServiceTest.java
@@ -49,13 +49,13 @@ class PlatformServiceTest {
     jpaRepository.save(
         new PlatformEntity(
             UUID.randomUUID(), "GitHub", ServiceCategory.DEVTOOL,
-            "https://api.github.com", 3000, 1000, null, true
+            "https://api.github.com", 3000, 1000, null, true, 200
         )
     );
     jpaRepository.save(
         new PlatformEntity(
             UUID.randomUUID(), "AWS", ServiceCategory.CLOUD,
-            "https://health.aws.amazon.com", 3000, 1000, null, true
+            "https://health.aws.amazon.com", 3000, 1000, null, true, 200
         )
     );
 


### PR DESCRIPTION
## 개요

각 플랫폼마다 기대하는 HTTP 응답 코드(`expected_status_code`)를 저장하고, 실제 응답 코드와 비교해 정확하게 상태를 판정합니다.

## 문제

기존에는 2xx → 정상, 4xx → PARTIAL_OUTAGE, 5xx → MAJOR_OUTAGE 로만 분류했기 때문에,
401/403이 정상 응답인 플랫폼(Claude, ChatGPT, Notion, Azure, Datadog)이 항상 PARTIAL_OUTAGE로 표시됨.

## 변경사항

- `Platform` 도메인 모델에 `expectedStatusCode` 필드 추가
- `PlatformEntity`에 `expected_status_code` 컬럼 추가
- `PlatformRepositoryImpl.toDomain()` 업데이트
- `HealthCheckPollService.determineStatus()` 시그니처 변경: `expectedStatusCode` 4번째 인자 추가
  - 기대 코드와 일치 → 응답시간으로 OPERATIONAL/DEGRADED 판단
  - 불일치 + 5xx → MAJOR_OUTAGE
  - 불일치 + 기타 → PARTIAL_OUTAGE
- `HealthCheckPollServiceTest` 7개 테스트로 확장

## DB 마이그레이션 (수동 실행 필요)

```sql
ALTER TABLE platforms ADD COLUMN expected_status_code INTEGER NOT NULL DEFAULT 200;

UPDATE platforms SET expected_status_code = 401 WHERE name IN ('Claude', 'ChatGPT', 'Notion', 'Azure', 'Datadog');
UPDATE platforms SET expected_status_code = 200 WHERE name = 'GitHub';
```

Closes #38