### PR TITLE
fix(healthcheck): 4xx 응답을 PARTIAL_OUTAGE 대신 OPERATIONAL로 처리

### DIFF
--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
@@ -62,8 +62,6 @@ public class HealthCheckPollService {
   ServiceStatus determineStatus(int httpStatus, long responseMs, int degradedThresholdMs) {
     if (httpStatus >= 500)
       return ServiceStatus.MAJOR_OUTAGE;
-    if (httpStatus >= 400)
-      return ServiceStatus.PARTIAL_OUTAGE;
     if (responseMs >= degradedThresholdMs)
       return ServiceStatus.DEGRADED;
     return ServiceStatus.OPERATIONAL;

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollServiceTest.java
@@ -30,13 +30,13 @@ class HealthCheckPollServiceTest {
   }
 
   @Test
-  void 응답이_4xx이면_PARTIAL_OUTAGE() {
+  void 응답이_4xx이면_OPERATIONAL() {
     ServiceStatus status = service.determineStatus(
         404,
         100,
         1000
     );
-    assertThat(status).isEqualTo(ServiceStatus.PARTIAL_OUTAGE);
+    assertThat(status).isEqualTo(ServiceStatus.OPERATIONAL);
   }
 
   @Test


### PR DESCRIPTION
## 요약
HTTP 4xx 응답을 PARTIAL_OUTAGE 대신 OPERATIONAL로 처리

## 작업사항
- `HealthCheckPollService.determineStatus()` — 4xx 조건 제거
- `HealthCheckPollServiceTest` — 테스트 케이스 업데이트

## 기타
Closes #38