### PR TITLE
feat(channel): 채널-플랫폼 구독 API 추가 (POST /channel-platforms)

### DIFF
--- a/api/src/main/java/com/nextdv/api/channel/ChannelPlatformController.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelPlatformController.java
@@ -1,0 +1,33 @@
+package com.nextdv.api.channel;
+
+import com.nextdv.api.common.ApiResponse;
+import com.nextdv.domain.channel.ChannelPlatform;
+import com.nextdv.domain.channel.ChannelPlatformService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/channel-platforms")
+public class ChannelPlatformController {
+
+  private final ChannelPlatformService channelPlatformService;
+
+  public ChannelPlatformController(ChannelPlatformService channelPlatformService) {
+    this.channelPlatformService = channelPlatformService;
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<ChannelPlatformResponse>> subscribe(
+      @RequestBody ChannelPlatformRequest request) {
+    ChannelPlatform channelPlatform = channelPlatformService.subscribe(
+        request.getChannelId(),
+        request.getPlatformId()
+    );
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResponse.ok(ChannelPlatformResponse.from(channelPlatform)));
+  }
+}

--- a/api/src/main/java/com/nextdv/api/channel/ChannelPlatformRequest.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelPlatformRequest.java
@@ -1,0 +1,11 @@
+package com.nextdv.api.channel;
+
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class ChannelPlatformRequest {
+
+  private UUID channelId;
+  private UUID platformId;
+}

--- a/api/src/main/java/com/nextdv/api/channel/ChannelPlatformResponse.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelPlatformResponse.java
@@ -1,0 +1,26 @@
+package com.nextdv.api.channel;
+
+import com.nextdv.domain.channel.ChannelPlatform;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChannelPlatformResponse {
+
+  private UUID id;
+  private UUID channelId;
+  private UUID platformId;
+  private Instant createdAt;
+
+  public static ChannelPlatformResponse from(ChannelPlatform channelPlatform) {
+    return new ChannelPlatformResponse(
+        channelPlatform.getId(),
+        channelPlatform.getChannelId(),
+        channelPlatform.getPlatformId(),
+        channelPlatform.getCreatedAt()
+    );
+  }
+}

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatform.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatform.java
@@ -1,0 +1,16 @@
+package com.nextdv.domain.channel;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChannelPlatform {
+
+  private final UUID id;
+  private final UUID channelId;
+  private final UUID platformId;
+  private final Instant createdAt;
+}

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformRepository.java
@@ -1,0 +1,10 @@
+package com.nextdv.domain.channel;
+
+import java.util.UUID;
+
+public interface ChannelPlatformRepository {
+
+  ChannelPlatform save(ChannelPlatform channelPlatform);
+
+  boolean existsByChannelIdAndPlatformId(UUID channelId, UUID platformId);
+}

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformService.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformService.java
@@ -1,0 +1,25 @@
+package com.nextdv.domain.channel;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChannelPlatformService {
+
+  private final ChannelPlatformRepository channelPlatformRepository;
+
+  public ChannelPlatform subscribe(UUID channelId, UUID platformId) {
+    if (channelPlatformRepository.existsByChannelIdAndPlatformId(
+        channelId,
+        platformId
+    )) {
+      throw new IllegalStateException("이미 구독 중입니다.");
+    }
+    return channelPlatformRepository.save(
+        new ChannelPlatform(UUID.randomUUID(), channelId, platformId, Instant.now())
+    );
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformEntity.java
@@ -1,0 +1,46 @@
+package com.nextdv.infrastructure.channel;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "channel_platforms")
+public class ChannelPlatformEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(name = "channel_id", nullable = false)
+  private UUID channelId;
+
+  @Column(name = "platform_id", nullable = false)
+  private UUID platformId;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @Column(name = "deleted_at")
+  private Instant deletedAt;
+
+  protected ChannelPlatformEntity() {
+  }
+
+  public ChannelPlatformEntity(UUID id, UUID channelId, UUID platformId, Instant createdAt) {
+    this(id, channelId, platformId, createdAt, null);
+  }
+
+  public ChannelPlatformEntity(
+      UUID id, UUID channelId, UUID platformId, Instant createdAt, Instant deletedAt) {
+    this.id = id;
+    this.channelId = channelId;
+    this.platformId = platformId;
+    this.createdAt = createdAt;
+    this.deletedAt = deletedAt;
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformJpaRepository.java
@@ -1,0 +1,9 @@
+package com.nextdv.infrastructure.channel;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChannelPlatformJpaRepository extends JpaRepository<ChannelPlatformEntity, UUID> {
+
+  boolean existsByChannelIdAndPlatformIdAndDeletedAtIsNull(UUID channelId, UUID platformId);
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.nextdv.infrastructure.channel;
+
+import com.nextdv.domain.channel.ChannelPlatform;
+import com.nextdv.domain.channel.ChannelPlatformRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChannelPlatformRepositoryImpl implements ChannelPlatformRepository {
+
+  private final ChannelPlatformJpaRepository jpaRepository;
+
+  @Override
+  public boolean existsByChannelIdAndPlatformId(UUID channelId, UUID platformId) {
+    return jpaRepository.existsByChannelIdAndPlatformIdAndDeletedAtIsNull(
+        channelId,
+        platformId
+    );
+  }
+
+  @Override
+  public ChannelPlatform save(ChannelPlatform channelPlatform) {
+    ChannelPlatformEntity entity = new ChannelPlatformEntity(
+        channelPlatform.getId(),
+        channelPlatform.getChannelId(),
+        channelPlatform.getPlatformId(),
+        channelPlatform.getCreatedAt()
+    );
+    ChannelPlatformEntity saved = jpaRepository.save(entity);
+    return new ChannelPlatform(
+        saved.getId(), saved.getChannelId(), saved.getPlatformId(), saved.getCreatedAt()
+    );
+  }
+}

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelPlatformServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelPlatformServiceTest.java
@@ -1,0 +1,87 @@
+package com.nextdv.infrastructure.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nextdv.domain.channel.ChannelPlatform;
+import com.nextdv.domain.channel.ChannelPlatformService;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import({ChannelPlatformRepositoryImpl.class, ChannelPlatformService.class})
+@Testcontainers
+class ChannelPlatformServiceTest {
+
+  @Container
+  @ServiceConnection
+  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+  @Autowired
+  private ChannelPlatformJpaRepository channelPlatformJpaRepository;
+
+  @Autowired
+  private ChannelPlatformService channelPlatformService;
+
+  @Test
+  void 채널과_플랫폼을_구독하면_저장하고_반환한다() {
+    UUID channelId = UUID.randomUUID();
+    UUID platformId = UUID.randomUUID();
+
+    ChannelPlatform result = channelPlatformService.subscribe(
+        channelId,
+        platformId
+    );
+
+    assertThat(result.getId()).isNotNull();
+    assertThat(result.getChannelId()).isEqualTo(channelId);
+    assertThat(result.getPlatformId()).isEqualTo(platformId);
+    assertThat(result.getCreatedAt()).isNotNull();
+  }
+
+  @Test
+  void 구독하면_DB에_실제로_저장된다() {
+    UUID channelId = UUID.randomUUID();
+    UUID platformId = UUID.randomUUID();
+
+    ChannelPlatform result = channelPlatformService.subscribe(
+        channelId,
+        platformId
+    );
+
+    ChannelPlatformEntity entity = channelPlatformJpaRepository.findById(result.getId())
+        .orElseThrow();
+    assertThat(entity.getChannelId()).isEqualTo(channelId);
+    assertThat(entity.getPlatformId()).isEqualTo(platformId);
+    assertThat(entity.getDeletedAt()).isNull();
+  }
+
+  @Test
+  void 이미_구독된_채널_플랫폼을_다시_구독하면_예외가_발생한다() {
+    UUID channelId = UUID.randomUUID();
+    UUID platformId = UUID.randomUUID();
+    channelPlatformService.subscribe(
+        channelId,
+        platformId
+    );
+
+    assertThatThrownBy(
+        () -> channelPlatformService.subscribe(
+            channelId,
+            platformId
+        )
+    )
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("이미 구독 중입니다.");
+  }
+}


### PR DESCRIPTION
## Summary

- channel → platform 알림 구독 관계를 저장하는 API 추가
- DB의 기존 `channel_platforms` 테이블 활용

## 변경사항

- `ChannelPlatform` 도메인 모델 + `ChannelPlatformRepository` + `ChannelPlatformService`
- `ChannelPlatformEntity` + JPA 구현체
- `POST /channel-platforms` 엔드포인트

## 의존관계

PR #64 머지 후 진행 권장