### PR TITLE
feat(api): Swagger UI 연동

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.1.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }


### PR DESCRIPTION
## 변경 내용

- springdoc-openapi 2.6.0 → 3.1.0 업그레이드 (Spring Boot 4.x 호환)
- AccountController.java 오타 수정 (`}1` → `}`)

## 배경

Spring Boot 4.1.0은 Spring Framework 7.x를 사용하는데, springdoc 2.x는 Spring Framework 6.x(Spring Boot 3.x) 전용이라 `/v3/api-docs` 500 에러 발생. springdoc 3.x부터 Spring Boot 4.x 지원.

## 확인

- 로컬에서 Swagger UI 정상 로드 확인 (`http://localhost:8080/swagger-ui/index.html`)
- 노출 엔드포인트: `/channels`, `/platforms`, `/health`, `/accounts`

Closes #69