### PR TITLE
feat(notification): 이메일 알림 발송 구현 (EmailSender 인터페이스 기반)

### DIFF
--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelRepository.java
@@ -11,4 +11,6 @@ public interface ChannelRepository {
   List<Channel> findAllByUserId(UUID userId);
 
   Optional<Channel> findById(UUID id);
+
+  List<Channel> findEmailChannelsByPlatformId(UUID platformId);
 }

--- a/domain/src/main/java/com/nextdv/domain/channel/EmailSender.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/EmailSender.java
@@ -1,0 +1,9 @@
+package com.nextdv.domain.channel;
+
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.Platform;
+
+public interface EmailSender {
+
+  void send(String address, Platform platform, ServiceStatus newStatus);
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelJpaRepository.java
@@ -3,8 +3,18 @@ package com.nextdv.infrastructure.channel;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChannelJpaRepository extends JpaRepository<ChannelEntity, UUID> {
 
   List<ChannelEntity> findAllByUserIdAndDeletedAtIsNull(UUID userId);
+
+  @Query("SELECT c FROM ChannelEntity c "
+      + "WHERE c.id IN ("
+      + "  SELECT cp.channelId FROM ChannelPlatformEntity cp "
+      + "  WHERE cp.platformId = :platformId AND cp.deletedAt IS NULL"
+      + ") AND c.deletedAt IS NULL AND c.type = :type")
+  List<ChannelEntity> findEmailChannelsByPlatformId(
+      @Param("platformId") UUID platformId, @Param("type") ChannelTypeEntity type);
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelRepositoryImpl.java
@@ -33,6 +33,18 @@ public class ChannelRepositoryImpl implements ChannelRepository {
     return channelJpaRepository.findById(id).map(this::toDomain);
   }
 
+  @Override
+  public List<Channel> findEmailChannelsByPlatformId(UUID platformId) {
+    return channelJpaRepository
+        .findEmailChannelsByPlatformId(
+            platformId,
+            ChannelTypeEntity.EMAIL
+        )
+        .stream()
+        .map(this::toDomain)
+        .toList();
+  }
+
   private ChannelEntity toEntity(Channel channel) {
     return new ChannelEntity(
         channel.getId(),

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
@@ -1,5 +1,7 @@
 package com.nextdv.infrastructure.healthcheck;
 
+import com.nextdv.domain.channel.ChannelRepository;
+import com.nextdv.domain.channel.EmailSender;
 import com.nextdv.domain.healthcheck.HealthCheckLog;
 import com.nextdv.domain.healthcheck.HealthCheckLogRepository;
 import com.nextdv.domain.healthcheck.ServiceStatus;
@@ -8,12 +10,14 @@ import com.nextdv.domain.platform.PlatformService;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class HealthCheckPollService {
@@ -21,12 +25,19 @@ public class HealthCheckPollService {
   private final PlatformService platformService;
   private final HealthCheckLogRepository healthCheckLogRepository;
   private final RestClient healthCheckRestClient;
+  private final ChannelRepository channelRepository;
+  private final EmailSender emailSender;
 
   public void pollAll() {
     platformService.findAll().forEach(this::poll);
   }
 
   private void poll(Platform platform) {
+    ServiceStatus previousStatus = healthCheckLogRepository
+        .findLatestByPlatformId(platform.getId())
+        .map(HealthCheckLog::getStatus)
+        .orElse(null);
+
     long startMs = System.currentTimeMillis();
     ServiceStatus status;
     Integer responseMs;
@@ -55,11 +66,40 @@ public class HealthCheckPollService {
       status = ServiceStatus.MAJOR_OUTAGE;
     }
 
+    notifyStatusChange(
+        platform,
+        previousStatus,
+        status
+    );
+
     healthCheckLogRepository.save(
         new HealthCheckLog(
             UUID.randomUUID(), platform.getId(), status, httpStatusCode, responseMs, Instant.now()
         )
     );
+  }
+
+  void notifyStatusChange(Platform platform, ServiceStatus previous, ServiceStatus current) {
+    if (previous == null || previous == current) {
+      return;
+    }
+    channelRepository.findEmailChannelsByPlatformId(platform.getId()).forEach(channel -> {
+      String address = (String) channel.getConfig().get("address");
+      try {
+        emailSender.send(
+            address,
+            platform,
+            current
+        );
+      } catch (Exception e) {
+        log.error(
+            "이메일 발송 실패 — 채널: {}, 주소: {}",
+            channel.getId(),
+            address,
+            e
+        );
+      }
+    });
   }
 
   ServiceStatus determineStatus(int httpStatus, int responseMs, int degradedThresholdMs) {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SmtpEmailSender.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SmtpEmailSender.java
@@ -1,0 +1,30 @@
+package com.nextdv.infrastructure.notification;
+
+import com.nextdv.domain.channel.EmailSender;
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.Platform;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SmtpEmailSender implements EmailSender {
+
+  private final JavaMailSender mailSender;
+
+  @Override
+  public void send(String address, Platform platform, ServiceStatus newStatus) {
+    SimpleMailMessage message = new SimpleMailMessage();
+    message.setTo(address);
+    message.setSubject("[Heartbeat] " + platform.getName() + " 상태 변화: " + newStatus.name());
+    message.setText(
+        platform.getName() + " 서비스 상태가 " + newStatus.name() + "으로 변경되었습니다.\n"
+            + "URL: " + platform.getHealthCheckUrl()
+    );
+    mailSender.send(message);
+  }
+}

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollNotificationTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollNotificationTest.java
@@ -1,0 +1,194 @@
+package com.nextdv.infrastructure.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nextdv.domain.channel.ChannelRepository;
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.Platform;
+import com.nextdv.domain.platform.ServiceCategory;
+import com.nextdv.infrastructure.channel.ChannelEntity;
+import com.nextdv.infrastructure.channel.ChannelJpaRepository;
+import com.nextdv.infrastructure.channel.ChannelPlatformEntity;
+import com.nextdv.infrastructure.channel.ChannelPlatformJpaRepository;
+import com.nextdv.infrastructure.channel.ChannelRepositoryImpl;
+import com.nextdv.infrastructure.channel.ChannelTypeEntity;
+import com.nextdv.infrastructure.notification.FakeEmailSender;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import(ChannelRepositoryImpl.class)
+@Testcontainers
+class HealthCheckPollNotificationTest {
+
+  @Container
+  @ServiceConnection
+  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+  @Autowired
+  private ChannelJpaRepository channelJpaRepository;
+
+  @Autowired
+  private ChannelPlatformJpaRepository channelPlatformJpaRepository;
+
+  @Autowired
+  private ChannelRepository channelRepository;
+
+  private FakeEmailSender fakeEmailSender;
+  private HealthCheckPollService service;
+
+  @BeforeEach
+  void setUp() {
+    fakeEmailSender = new FakeEmailSender();
+    service = new HealthCheckPollService(null, null, null, channelRepository, fakeEmailSender);
+  }
+
+  @Test
+  void 상태변화_시_이메일_채널에_알림이_발송된다() {
+    UUID platformId = UUID.randomUUID();
+    UUID channelId = UUID.randomUUID();
+    Instant now = Instant.now();
+
+    channelJpaRepository.save(
+        new ChannelEntity(
+            channelId, UUID.randomUUID(), ChannelTypeEntity.EMAIL,
+            "이메일", Map.of(
+                "address",
+                "user@example.com"
+            ), now, now, null
+        )
+    );
+    channelPlatformJpaRepository.save(
+        new ChannelPlatformEntity(UUID.randomUUID(), channelId, platformId, now)
+    );
+
+    Platform platform = new Platform(
+        platformId, "GitHub", ServiceCategory.DEVTOOL,
+        "https://github.com", 5000, 2000, null, true
+    );
+
+    service.notifyStatusChange(
+        platform,
+        ServiceStatus.OPERATIONAL,
+        ServiceStatus.MAJOR_OUTAGE
+    );
+
+    assertThat(fakeEmailSender.getSentAddresses()).containsExactly("user@example.com");
+  }
+
+  @Test
+  void 상태가_같으면_알림이_발송되지_않는다() {
+    Platform platform = new Platform(
+        UUID.randomUUID(), "GitHub", ServiceCategory.DEVTOOL,
+        "https://github.com", 5000, 2000, null, true
+    );
+
+    service.notifyStatusChange(
+        platform,
+        ServiceStatus.OPERATIONAL,
+        ServiceStatus.OPERATIONAL
+    );
+
+    assertThat(fakeEmailSender.getSentAddresses()).isEmpty();
+  }
+
+  @Test
+  void 이전_상태가_없으면_알림이_발송되지_않는다() {
+    Platform platform = new Platform(
+        UUID.randomUUID(), "GitHub", ServiceCategory.DEVTOOL,
+        "https://github.com", 5000, 2000, null, true
+    );
+
+    service.notifyStatusChange(
+        platform,
+        null,
+        ServiceStatus.MAJOR_OUTAGE
+    );
+
+    assertThat(fakeEmailSender.getSentAddresses()).isEmpty();
+  }
+
+  @Test
+  void 소프트삭제된_구독은_알림이_발송되지_않는다() {
+    UUID platformId = UUID.randomUUID();
+    UUID channelId = UUID.randomUUID();
+    Instant now = Instant.now();
+
+    channelJpaRepository.save(
+        new ChannelEntity(
+            channelId, UUID.randomUUID(), ChannelTypeEntity.EMAIL,
+            "이메일", Map.of(
+                "address",
+                "user@example.com"
+            ), now, now, null
+        )
+    );
+    channelPlatformJpaRepository.save(
+        new ChannelPlatformEntity(UUID.randomUUID(), channelId, platformId, now, now)
+    );
+
+    Platform platform = new Platform(
+        platformId, "GitHub", ServiceCategory.DEVTOOL,
+        "https://github.com", 5000, 2000, null, true
+    );
+
+    service.notifyStatusChange(
+        platform,
+        ServiceStatus.OPERATIONAL,
+        ServiceStatus.MAJOR_OUTAGE
+    );
+
+    assertThat(fakeEmailSender.getSentAddresses()).isEmpty();
+  }
+
+  @Test
+  void 이미_발송된_상태에서_같은_상태가_유지되면_추가_알림이_발송되지_않는다() {
+    UUID platformId = UUID.randomUUID();
+    UUID channelId = UUID.randomUUID();
+    Instant now = Instant.now();
+
+    channelJpaRepository.save(
+        new ChannelEntity(
+            channelId, UUID.randomUUID(), ChannelTypeEntity.EMAIL,
+            "이메일", Map.of(
+                "address",
+                "user@example.com"
+            ), now, now, null
+        )
+    );
+    channelPlatformJpaRepository.save(
+        new ChannelPlatformEntity(UUID.randomUUID(), channelId, platformId, now)
+    );
+
+    Platform platform = new Platform(
+        platformId, "GitHub", ServiceCategory.DEVTOOL,
+        "https://github.com", 5000, 2000, null, true
+    );
+
+    service.notifyStatusChange(
+        platform,
+        ServiceStatus.OPERATIONAL,
+        ServiceStatus.MAJOR_OUTAGE
+    );
+    service.notifyStatusChange(
+        platform,
+        ServiceStatus.MAJOR_OUTAGE,
+        ServiceStatus.MAJOR_OUTAGE
+    );
+
+    assertThat(fakeEmailSender.getSentAddresses()).hasSize(1);
+  }
+}

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollServiceTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.Test;
 
 class HealthCheckPollServiceTest {
 
-  private final HealthCheckPollService service = new HealthCheckPollService(null, null, null);
+  private final HealthCheckPollService service = new HealthCheckPollService(
+      null, null, null, null, null
+  );
 
   @Test
   void 응답이_2xx이고_임계값_미만이면_OPERATIONAL() {

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/notification/FakeEmailSender.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/notification/FakeEmailSender.java
@@ -1,0 +1,21 @@
+package com.nextdv.infrastructure.notification;
+
+import com.nextdv.domain.channel.EmailSender;
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.Platform;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FakeEmailSender implements EmailSender {
+
+  private final List<String> sentAddresses = new ArrayList<>();
+
+  @Override
+  public void send(String address, Platform platform, ServiceStatus newStatus) {
+    sentAddresses.add(address);
+  }
+
+  public List<String> getSentAddresses() {
+    return sentAddresses;
+  }
+}


### PR DESCRIPTION
## 배경
PR #67이 feat/channel-platform-subscription으로 잘못 머지되어 main에 반영되지 않았음. 동일 내용을 main 대상으로 재오픈.

## 변경사항
- `EmailSender` 인터페이스 (domain) — 구현체 교체 가능 구조
- `SmtpEmailSender` — JavaMailSender 기반 Gmail SMTP 구현체
- `HealthCheckPollService` — 상태 변화 감지 후 알림 발송, 실패 시 로그만 남기고 폴링 계속
- `ChannelRepository.findEmailChannelsByPlatformId()` — channel_platforms JOIN 쿼리

## 테스트
`HealthCheckPollNotificationTest` (Testcontainers + FakeEmailSender)
- 상태 변화 시 이메일 발송
- 상태 동일 시 발송 안 함
- 첫 폴링(이전 상태 없음) 시 발송 안 함
- 소프트 삭제된 구독 발송 안 함

Closes #69