### PR TITLE
feat(platform): application.yml 기반 플랫폼 시드 데이터 삽입

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -25,3 +25,90 @@ spring:
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
+
+heartbeat:
+  platforms:
+    - name: Claude
+      category: AI
+      healthCheckUrl: https://status.anthropic.com/api/v2/summary.json
+      timeoutMs: 5000
+      degradedThresholdMs: 2000
+      iconUrl: https://www.anthropic.com/favicon.ico
+    - name: ChatGPT
+      category: AI
+      healthCheckUrl: https://status.openai.com/api/v2/summary.json
+      timeoutMs: 5000
+      degradedThresholdMs: 2000
+      iconUrl: https://openai.com/favicon.ico
+    - name: Gemini
+      category: AI
+      healthCheckUrl: https://status.cloud.google.com/incidents.json
+      timeoutMs: 5000
+      degradedThresholdMs: 2000
+      iconUrl: https://www.gstatic.com/lamda/images/gemini_favicon_f069958c85030456e93de685481c559f160ea06.svg
+    - name: GitHub
+      category: DEVTOOL
+      healthCheckUrl: https://www.githubstatus.com/api/v2/summary.json
+      timeoutMs: 5000
+      degradedThresholdMs: 2000
+      iconUrl: https://github.com/favicon.ico
+    - name: AWS
+      category: CLOUD
+      healthCheckUrl: https://status.aws.amazon.com/rss/all.rss
+      timeoutMs: 5000
+      degradedThresholdMs: 2000
+      iconUrl: https://a0.awsstatic.com/libra-css/images/logos/aws_logo_smile_1200x630.png
+    - name: Azure
+      category: CLOUD
+      healthCheckUrl: https://azure.status.microsoft/en-us/status/feed/
+      timeoutMs: 5000
+      degradedThresholdMs: 2000
+      iconUrl: https://azure.microsoft.com/favicon.ico
+    - name: GCP
+      category: CLOUD
+      healthCheckUrl: https://status.cloud.google.com/incidents.json
+      timeoutMs: 5000
+      degradedThresholdMs: 2000
+      iconUrl: https://cloud.google.com/favicon.ico
+    - name: Slack
+      category: COMMUNICATION
+      healthCheckUrl: https://status.slack.com/api/v2.0.0/current
+      timeoutMs: 5000
+      degradedThresholdMs: 2000
+      iconUrl: https://slack.com/favicon.ico
+    - name: Discord
+      category: COMMUNICATION
+      healthCheckUrl: https://discordstatus.com/api/v2/summary.json
+      timeoutMs: 5000
+      degradedThresholdMs: 2000
+      iconUrl: https://discord.com/favicon.ico
+    - name: Notion
+      category: DEVTOOL
+      healthCheckUrl: https://status.notion.so/api/v2/summary.json
+      timeoutMs: 5000
+      degradedThresholdMs: 2000
+      iconUrl: https://www.notion.so/favicon.ico
+    - name: Cloudflare
+      category: CLOUD
+      healthCheckUrl: https://www.cloudflarestatus.com/api/v2/summary.json
+      timeoutMs: 5000
+      degradedThresholdMs: 2000
+      iconUrl: https://www.cloudflare.com/favicon.ico
+    - name: Vercel
+      category: CLOUD
+      healthCheckUrl: https://www.vercel-status.com/api/v2/summary.json
+      timeoutMs: 5000
+      degradedThresholdMs: 2000
+      iconUrl: https://vercel.com/favicon.ico
+    - name: Datadog
+      category: DEVTOOL
+      healthCheckUrl: https://status.datadoghq.com/api/v2/summary.json
+      timeoutMs: 5000
+      degradedThresholdMs: 2000
+      iconUrl: https://www.datadoghq.com/favicon.ico
+    - name: Jira
+      category: DEVTOOL
+      healthCheckUrl: https://jira-software.status.atlassian.com/api/v2/summary.json
+      timeoutMs: 5000
+      degradedThresholdMs: 2000
+      iconUrl: https://wac-cdn.atlassian.com/assets/img/favicons/atlassian/favicon.png

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/JpaConfig.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/JpaConfig.java
@@ -1,5 +1,7 @@
 package com.nextdv.infrastructure;
 
+import com.nextdv.infrastructure.platform.PlatformProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -7,5 +9,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @Configuration
 @EntityScan("com.nextdv.infrastructure")
 @EnableJpaRepositories("com.nextdv.infrastructure")
+@EnableConfigurationProperties(PlatformProperties.class)
 public class JpaConfig {
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformDataInitializer.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformDataInitializer.java
@@ -1,0 +1,42 @@
+package com.nextdv.infrastructure.platform;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlatformDataInitializer implements ApplicationRunner {
+
+  private final PlatformJpaRepository platformJpaRepository;
+  private final PlatformProperties platformProperties;
+
+  @Override
+  public void run(ApplicationArguments args) {
+    Set<String> existingNames = platformJpaRepository.findAll().stream()
+        .map(PlatformEntity::getName)
+        .collect(Collectors.toSet());
+
+    platformProperties.platforms().stream()
+        .filter(config -> !existingNames.contains(config.name()))
+        .map(this::toEntity)
+        .forEach(platformJpaRepository::save);
+  }
+
+  private PlatformEntity toEntity(PlatformProperties.PlatformConfig config) {
+    return new PlatformEntity(
+        UUID.randomUUID(),
+        config.name(),
+        config.category(),
+        config.healthCheckUrl(),
+        config.timeoutMs(),
+        config.degradedThresholdMs(),
+        config.iconUrl(),
+        true
+    );
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformProperties.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformProperties.java
@@ -1,0 +1,18 @@
+package com.nextdv.infrastructure.platform;
+
+import com.nextdv.domain.platform.ServiceCategory;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("heartbeat")
+public record PlatformProperties(List<PlatformConfig> platforms) {
+
+  public record PlatformConfig(
+      String name,
+      ServiceCategory category,
+      String healthCheckUrl,
+      int timeoutMs,
+      int degradedThresholdMs,
+      String iconUrl) {
+  }
+}


### PR DESCRIPTION
## 변경사항

앱 시작 시 `application.yml`에 정의된 플랫폼 목록을 읽어 DB에 자동 삽입.
name 기준 중복 체크로 재시작 시 중복 삽입 없음.

## 신규 파일
- `PlatformProperties` — `@ConfigurationProperties("heartbeat")` 바인딩
- `PlatformDataInitializer` — ApplicationRunner, name 기준 upsert

## 수정 파일
- `JpaConfig` — `@EnableConfigurationProperties(PlatformProperties.class)` 추가
- `application.yml` — `heartbeat.platforms` 섹션에 기본 14개 플랫폼 정의

Closes #73