### PR TITLE
채널 등록 시 타입별 config 필수 필드 검증 추가

### DIFF
--- a/api/src/main/java/com/nextdv/api/common/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/nextdv/api/common/GlobalExceptionHandler.java
@@ -14,6 +14,11 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.fail(e.getMessage()));
   }
 
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<ApiResponse<Void>> handleBadRequest(IllegalArgumentException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.fail(e.getMessage()));
+  }
+
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelService.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelService.java
@@ -15,9 +15,38 @@ public class ChannelService {
 
   public Channel create(
       UUID userId, ChannelType type, String name, Map<String, Object> config) {
+    validateConfig(
+        type,
+        config
+    );
     Instant now = Instant.now();
     Channel channel = new Channel(UUID.randomUUID(), userId, type, name, config, now, now, null);
     return channelRepository.save(channel);
+  }
+
+  private void validateConfig(ChannelType type, Map<String, Object> config) {
+    switch (type) {
+      case EMAIL -> {
+        Object address = config.get("address");
+        if (!(address instanceof String s) || s.isBlank()) {
+          throw new IllegalArgumentException("EMAIL 채널은 config.address가 필요합니다.");
+        }
+      }
+      case SLACK -> {
+        Object url = config.get("url");
+        if (!(url instanceof String s) || s.isBlank()) {
+          throw new IllegalArgumentException("SLACK 채널은 config.url이 필요합니다.");
+        }
+      }
+      case DISCORD -> {
+        Object url = config.get("url");
+        if (!(url instanceof String s) || s.isBlank()) {
+          throw new IllegalArgumentException("DISCORD 채널은 config.url이 필요합니다.");
+        }
+      }
+      default -> {
+      }
+    }
   }
 
   public List<Channel> findAllByUserId(UUID userId) {

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelServiceTest.java
@@ -127,4 +127,28 @@ class ChannelServiceTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("채널을 찾을 수 없습니다.");
   }
+
+  @Test
+  void EMAIL_채널_config에_address가_없으면_예외가_발생한다() {
+    assertThatThrownBy(() -> channelService.create(
+            UUID.randomUUID(), ChannelType.EMAIL, "이메일", Map.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("EMAIL 채널은 config.address가 필요합니다.");
+  }
+
+  @Test
+  void SLACK_채널_config에_url이_없으면_예외가_발생한다() {
+    assertThatThrownBy(() -> channelService.create(
+            UUID.randomUUID(), ChannelType.SLACK, "슬랙", Map.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("SLACK 채널은 config.url이 필요합니다.");
+  }
+
+  @Test
+  void DISCORD_채널_config에_url이_없으면_예외가_발생한다() {
+    assertThatThrownBy(() -> channelService.create(
+            UUID.randomUUID(), ChannelType.DISCORD, "디스코드", Map.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("DISCORD 채널은 config.url이 필요합니다.");
+  }
 }

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelServiceTest.java
@@ -41,8 +41,8 @@ class ChannelServiceTest {
   void 채널을_생성하면_저장하고_반환한다() {
     UUID userId = UUID.randomUUID();
     Map<String, Object> config = Map.of(
-        "webhook",
-        "https://example.com"
+        "url",
+        "https://hooks.slack.com/example"
     );
 
     Channel result = channelService.create(
@@ -87,7 +87,10 @@ class ChannelServiceTest {
         userId,
         ChannelType.EMAIL,
         "이메일",
-        Map.of()
+        Map.of(
+            "address",
+            "test@example.com"
+        )
     );
 
     channelService.delete(created.getId());
@@ -103,13 +106,19 @@ class ChannelServiceTest {
         userId,
         ChannelType.SLACK,
         "활성 채널",
-        Map.of()
+        Map.of(
+            "url",
+            "https://hooks.slack.com/active"
+        )
     );
     Channel deleted = channelService.create(
         userId,
         ChannelType.DISCORD,
         "삭제된 채널",
-        Map.of()
+        Map.of(
+            "url",
+            "https://discord.com/api/webhooks/deleted"
+        )
     );
     channelService.delete(deleted.getId());
 
@@ -130,24 +139,42 @@ class ChannelServiceTest {
 
   @Test
   void EMAIL_채널_config에_address가_없으면_예외가_발생한다() {
-    assertThatThrownBy(() -> channelService.create(
-            UUID.randomUUID(), ChannelType.EMAIL, "이메일", Map.of()))
+    assertThatThrownBy(
+        () -> channelService.create(
+            UUID.randomUUID(),
+            ChannelType.EMAIL,
+            "이메일",
+            Map.of()
+        )
+    )
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("EMAIL 채널은 config.address가 필요합니다.");
   }
 
   @Test
   void SLACK_채널_config에_url이_없으면_예외가_발생한다() {
-    assertThatThrownBy(() -> channelService.create(
-            UUID.randomUUID(), ChannelType.SLACK, "슬랙", Map.of()))
+    assertThatThrownBy(
+        () -> channelService.create(
+            UUID.randomUUID(),
+            ChannelType.SLACK,
+            "슬랙",
+            Map.of()
+        )
+    )
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("SLACK 채널은 config.url이 필요합니다.");
   }
 
   @Test
   void DISCORD_채널_config에_url이_없으면_예외가_발생한다() {
-    assertThatThrownBy(() -> channelService.create(
-            UUID.randomUUID(), ChannelType.DISCORD, "디스코드", Map.of()))
+    assertThatThrownBy(
+        () -> channelService.create(
+            UUID.randomUUID(),
+            ChannelType.DISCORD,
+            "디스코드",
+            Map.of()
+        )
+    )
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("DISCORD 채널은 config.url이 필요합니다.");
   }


### PR DESCRIPTION
## 배경
채널의 `config` 컬럼은 JSONB라 DB에서 NotNull만 확인하고 내부 내용은 검증하지 않아, 잘못된 config로 채널이 등록돼도 알림이 조용히 누락되는 문제가 있었습니다.

## 변경 사항
- EMAIL: `config.address` 누락 시 400 반환
- SLACK: `config.url` 누락 시 400 반환
- DISCORD: `config.url` 누락 시 400 반환
- `GlobalExceptionHandler`에 `IllegalArgumentException` → 400 핸들러 추가

Closes #80