### PR TITLE
feat(notification): Slack/Discord webhook 알림 발송 구현

### DIFF
--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelRepository.java
@@ -13,4 +13,8 @@ public interface ChannelRepository {
   Optional<Channel> findById(UUID id);
 
   List<Channel> findEmailChannelsByPlatformId(UUID platformId);
+
+  List<Channel> findSlackChannelsByPlatformId(UUID platformId);
+
+  List<Channel> findDiscordChannelsByPlatformId(UUID platformId);
 }

--- a/domain/src/main/java/com/nextdv/domain/channel/DiscordSender.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/DiscordSender.java
@@ -1,0 +1,9 @@
+package com.nextdv.domain.channel;
+
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.Platform;
+
+public interface DiscordSender {
+
+  void send(String webhookUrl, Platform platform, ServiceStatus newStatus);
+}

--- a/domain/src/main/java/com/nextdv/domain/channel/SlackSender.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/SlackSender.java
@@ -1,0 +1,9 @@
+package com.nextdv.domain.channel;
+
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.Platform;
+
+public interface SlackSender {
+
+  void send(String webhookUrl, Platform platform, ServiceStatus newStatus);
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelJpaRepository.java
@@ -15,6 +15,6 @@ public interface ChannelJpaRepository extends JpaRepository<ChannelEntity, UUID>
       + "  SELECT cp.channelId FROM ChannelPlatformEntity cp "
       + "  WHERE cp.platformId = :platformId AND cp.deletedAt IS NULL"
       + ") AND c.deletedAt IS NULL AND c.type = :type")
-  List<ChannelEntity> findEmailChannelsByPlatformId(
+  List<ChannelEntity> findChannelsByPlatformIdAndType(
       @Param("platformId") UUID platformId, @Param("type") ChannelTypeEntity type);
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelRepositoryImpl.java
@@ -36,9 +36,33 @@ public class ChannelRepositoryImpl implements ChannelRepository {
   @Override
   public List<Channel> findEmailChannelsByPlatformId(UUID platformId) {
     return channelJpaRepository
-        .findEmailChannelsByPlatformId(
+        .findChannelsByPlatformIdAndType(
             platformId,
             ChannelTypeEntity.EMAIL
+        )
+        .stream()
+        .map(this::toDomain)
+        .toList();
+  }
+
+  @Override
+  public List<Channel> findSlackChannelsByPlatformId(UUID platformId) {
+    return channelJpaRepository
+        .findChannelsByPlatformIdAndType(
+            platformId,
+            ChannelTypeEntity.SLACK
+        )
+        .stream()
+        .map(this::toDomain)
+        .toList();
+  }
+
+  @Override
+  public List<Channel> findDiscordChannelsByPlatformId(UUID platformId) {
+    return channelJpaRepository
+        .findChannelsByPlatformIdAndType(
+            platformId,
+            ChannelTypeEntity.DISCORD
         )
         .stream()
         .map(this::toDomain)

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
@@ -1,7 +1,9 @@
 package com.nextdv.infrastructure.healthcheck;
 
 import com.nextdv.domain.channel.ChannelRepository;
+import com.nextdv.domain.channel.DiscordSender;
 import com.nextdv.domain.channel.EmailSender;
+import com.nextdv.domain.channel.SlackSender;
 import com.nextdv.domain.healthcheck.HealthCheckLog;
 import com.nextdv.domain.healthcheck.HealthCheckLogRepository;
 import com.nextdv.domain.healthcheck.ServiceStatus;
@@ -27,6 +29,8 @@ public class HealthCheckPollService {
   private final RestClient healthCheckRestClient;
   private final ChannelRepository channelRepository;
   private final EmailSender emailSender;
+  private final SlackSender slackSender;
+  private final DiscordSender discordSender;
 
   public void pollAll() {
     platformService.findAll().forEach(this::poll);
@@ -96,6 +100,40 @@ public class HealthCheckPollService {
             "이메일 발송 실패 — 채널: {}, 주소: {}",
             channel.getId(),
             address,
+            e
+        );
+      }
+    });
+    channelRepository.findSlackChannelsByPlatformId(platform.getId()).forEach(channel -> {
+      String url = (String) channel.getConfig().get("url");
+      try {
+        slackSender.send(
+            url,
+            platform,
+            current
+        );
+      } catch (Exception e) {
+        log.error(
+            "Slack 발송 실패 — 채널: {}, URL: {}",
+            channel.getId(),
+            url,
+            e
+        );
+      }
+    });
+    channelRepository.findDiscordChannelsByPlatformId(platform.getId()).forEach(channel -> {
+      String url = (String) channel.getConfig().get("url");
+      try {
+        discordSender.send(
+            url,
+            platform,
+            current
+        );
+      } catch (Exception e) {
+        log.error(
+            "Discord 발송 실패 — 채널: {}, URL: {}",
+            channel.getId(),
+            url,
             e
         );
       }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/notification/DiscordWebhookSender.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/notification/DiscordWebhookSender.java
@@ -1,0 +1,34 @@
+package com.nextdv.infrastructure.notification;
+
+import com.nextdv.domain.channel.DiscordSender;
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.Platform;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DiscordWebhookSender implements DiscordSender {
+
+  private final RestClient restClient;
+
+  @Override
+  public void send(String webhookUrl, Platform platform, ServiceStatus newStatus) {
+    String content = "[Heartbeat] " + platform.getName() + " 상태 변화: " + newStatus.name();
+    restClient
+        .post()
+        .uri(webhookUrl)
+        .body(
+            Map.of(
+                "content",
+                content
+            )
+        )
+        .retrieve()
+        .toBodilessEntity();
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SlackWebhookSender.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SlackWebhookSender.java
@@ -1,0 +1,34 @@
+package com.nextdv.infrastructure.notification;
+
+import com.nextdv.domain.channel.SlackSender;
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.Platform;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SlackWebhookSender implements SlackSender {
+
+  private final RestClient restClient;
+
+  @Override
+  public void send(String webhookUrl, Platform platform, ServiceStatus newStatus) {
+    String text = "[Heartbeat] " + platform.getName() + " 상태 변화: " + newStatus.name();
+    restClient
+        .post()
+        .uri(webhookUrl)
+        .body(
+            Map.of(
+                "text",
+                text
+            )
+        )
+        .retrieve()
+        .toBodilessEntity();
+  }
+}

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollNotificationTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollNotificationTest.java
@@ -12,7 +12,9 @@ import com.nextdv.infrastructure.channel.ChannelPlatformEntity;
 import com.nextdv.infrastructure.channel.ChannelPlatformJpaRepository;
 import com.nextdv.infrastructure.channel.ChannelRepositoryImpl;
 import com.nextdv.infrastructure.channel.ChannelTypeEntity;
+import com.nextdv.infrastructure.notification.FakeDiscordSender;
 import com.nextdv.infrastructure.notification.FakeEmailSender;
+import com.nextdv.infrastructure.notification.FakeSlackSender;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
@@ -48,12 +50,18 @@ class HealthCheckPollNotificationTest {
   private ChannelRepository channelRepository;
 
   private FakeEmailSender fakeEmailSender;
+  private FakeSlackSender fakeSlackSender;
+  private FakeDiscordSender fakeDiscordSender;
   private HealthCheckPollService service;
 
   @BeforeEach
   void setUp() {
     fakeEmailSender = new FakeEmailSender();
-    service = new HealthCheckPollService(null, null, null, channelRepository, fakeEmailSender);
+    fakeSlackSender = new FakeSlackSender();
+    fakeDiscordSender = new FakeDiscordSender();
+    service = new HealthCheckPollService(
+        null, null, null, channelRepository, fakeEmailSender, fakeSlackSender, fakeDiscordSender
+    );
   }
 
   @Test
@@ -190,5 +198,59 @@ class HealthCheckPollNotificationTest {
     );
 
     assertThat(fakeEmailSender.getSentAddresses()).hasSize(1);
+  }
+
+  @Test
+  void 상태변화_시_Slack_채널에_알림이_발송된다() {
+    UUID platformId = UUID.randomUUID();
+    UUID channelId = UUID.randomUUID();
+    Instant now = Instant.now();
+
+    channelJpaRepository.save(
+        new ChannelEntity(
+            channelId, UUID.randomUUID(), ChannelTypeEntity.SLACK,
+            "슬랙", Map.of("url", "https://hooks.slack.com/test"), now, now, null
+        )
+    );
+    channelPlatformJpaRepository.save(
+        new ChannelPlatformEntity(UUID.randomUUID(), channelId, platformId, now)
+    );
+
+    Platform platform = new Platform(
+        platformId, "GitHub", ServiceCategory.DEVTOOL,
+        "https://github.com", 5000, 2000, null, true
+    );
+
+    service.notifyStatusChange(platform, ServiceStatus.OPERATIONAL, ServiceStatus.MAJOR_OUTAGE);
+
+    assertThat(fakeSlackSender.getSentUrls()).containsExactly("https://hooks.slack.com/test");
+  }
+
+  @Test
+  void 상태변화_시_Discord_채널에_알림이_발송된다() {
+    UUID platformId = UUID.randomUUID();
+    UUID channelId = UUID.randomUUID();
+    Instant now = Instant.now();
+
+    channelJpaRepository.save(
+        new ChannelEntity(
+            channelId, UUID.randomUUID(), ChannelTypeEntity.DISCORD,
+            "디스코드", Map.of("url", "https://discord.com/api/webhooks/test"), now, now, null
+        )
+    );
+    channelPlatformJpaRepository.save(
+        new ChannelPlatformEntity(UUID.randomUUID(), channelId, platformId, now)
+    );
+
+    Platform platform = new Platform(
+        platformId, "GitHub", ServiceCategory.DEVTOOL,
+        "https://github.com", 5000, 2000, null, true
+    );
+
+    service.notifyStatusChange(platform, ServiceStatus.OPERATIONAL, ServiceStatus.MAJOR_OUTAGE);
+
+    assertThat(fakeDiscordSender.getSentUrls()).containsExactly(
+        "https://discord.com/api/webhooks/test"
+    );
   }
 }

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollNotificationTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollNotificationTest.java
@@ -209,7 +209,10 @@ class HealthCheckPollNotificationTest {
     channelJpaRepository.save(
         new ChannelEntity(
             channelId, UUID.randomUUID(), ChannelTypeEntity.SLACK,
-            "슬랙", Map.of("url", "https://hooks.slack.com/test"), now, now, null
+            "슬랙", Map.of(
+                "url",
+                "https://hooks.slack.com/test"
+            ), now, now, null
         )
     );
     channelPlatformJpaRepository.save(
@@ -221,7 +224,11 @@ class HealthCheckPollNotificationTest {
         "https://github.com", 5000, 2000, null, true
     );
 
-    service.notifyStatusChange(platform, ServiceStatus.OPERATIONAL, ServiceStatus.MAJOR_OUTAGE);
+    service.notifyStatusChange(
+        platform,
+        ServiceStatus.OPERATIONAL,
+        ServiceStatus.MAJOR_OUTAGE
+    );
 
     assertThat(fakeSlackSender.getSentUrls()).containsExactly("https://hooks.slack.com/test");
   }
@@ -235,7 +242,10 @@ class HealthCheckPollNotificationTest {
     channelJpaRepository.save(
         new ChannelEntity(
             channelId, UUID.randomUUID(), ChannelTypeEntity.DISCORD,
-            "디스코드", Map.of("url", "https://discord.com/api/webhooks/test"), now, now, null
+            "디스코드", Map.of(
+                "url",
+                "https://discord.com/api/webhooks/test"
+            ), now, now, null
         )
     );
     channelPlatformJpaRepository.save(
@@ -247,7 +257,11 @@ class HealthCheckPollNotificationTest {
         "https://github.com", 5000, 2000, null, true
     );
 
-    service.notifyStatusChange(platform, ServiceStatus.OPERATIONAL, ServiceStatus.MAJOR_OUTAGE);
+    service.notifyStatusChange(
+        platform,
+        ServiceStatus.OPERATIONAL,
+        ServiceStatus.MAJOR_OUTAGE
+    );
 
     assertThat(fakeDiscordSender.getSentUrls()).containsExactly(
         "https://discord.com/api/webhooks/test"

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollServiceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 class HealthCheckPollServiceTest {
 
   private final HealthCheckPollService service = new HealthCheckPollService(
-      null, null, null, null, null
+      null, null, null, null, null, null, null
   );
 
   @Test

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/notification/FakeDiscordSender.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/notification/FakeDiscordSender.java
@@ -1,0 +1,21 @@
+package com.nextdv.infrastructure.notification;
+
+import com.nextdv.domain.channel.DiscordSender;
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.Platform;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FakeDiscordSender implements DiscordSender {
+
+  private final List<String> sentUrls = new ArrayList<>();
+
+  @Override
+  public void send(String webhookUrl, Platform platform, ServiceStatus newStatus) {
+    sentUrls.add(webhookUrl);
+  }
+
+  public List<String> getSentUrls() {
+    return sentUrls;
+  }
+}

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/notification/FakeSlackSender.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/notification/FakeSlackSender.java
@@ -1,0 +1,21 @@
+package com.nextdv.infrastructure.notification;
+
+import com.nextdv.domain.channel.SlackSender;
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.Platform;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FakeSlackSender implements SlackSender {
+
+  private final List<String> sentUrls = new ArrayList<>();
+
+  @Override
+  public void send(String webhookUrl, Platform platform, ServiceStatus newStatus) {
+    sentUrls.add(webhookUrl);
+  }
+
+  public List<String> getSentUrls() {
+    return sentUrls;
+  }
+}


### PR DESCRIPTION
## 변경 사항
- `SlackSender`, `DiscordSender` 인터페이스 추가
- `SlackWebhookSender`, `DiscordWebhookSender` 구현체 추가 (RestClient)
- `ChannelRepository`에 Slack/Discord 채널 조회 메서드 추가
- `HealthCheckPollService.notifyStatusChange()`에 Slack/Discord 발송 로직 추가
- 기존 `findEmailChannelsByPlatformId` 쿼리를 `findChannelsByPlatformIdAndType`으로 통합

## 참고
PR #72 머지 후 rebase 필요

Closes #74