### PR TITLE
feat(account): 이메일 기반 계정 등록 API 추가

### DIFF
--- a/api/src/main/java/com/nextdv/api/account/AccountController.java
+++ b/api/src/main/java/com/nextdv/api/account/AccountController.java
@@ -5,8 +5,11 @@ import com.nextdv.domain.account.Account;
 import com.nextdv.domain.account.AccountService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,5 +25,12 @@ public class AccountController {
     List<Account> accounts = accountService.findAll();
     List<AccountResponse> data = AccountMapper.toResponseList(accounts);
     return ResponseEntity.ok(ApiResponse.ok(data));
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<AccountResponse>> create(@RequestBody AccountRequest request) {
+    Account account = accountService.create(request.getEmail());
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResponse.ok(AccountMapper.toResponse(account)));
   }
 }

--- a/domain/src/main/java/com/nextdv/domain/account/AccountRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/account/AccountRepository.java
@@ -5,4 +5,6 @@ import java.util.List;
 public interface AccountRepository {
 
   List<Account> findAll();
+
+  Account save(Account account);
 }

--- a/domain/src/main/java/com/nextdv/domain/account/AccountService.java
+++ b/domain/src/main/java/com/nextdv/domain/account/AccountService.java
@@ -1,6 +1,7 @@
 package com.nextdv.domain.account;
 
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,5 +13,9 @@ public class AccountService {
 
   public List<Account> findAll() {
     return accountRepository.findAll();
+  }
+
+  public Account create(String email) {
+    return accountRepository.save(new Account(UUID.randomUUID(), email));
   }
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountRepositoryImpl.java
@@ -18,4 +18,12 @@ public class AccountRepositoryImpl implements AccountRepository {
         .map(entity -> new Account(entity.getId(), entity.getEmail()))
         .toList();
   }
+
+  @Override
+  public Account save(Account account) {
+    AccountEntity saved = accountJpaRepository.save(
+        new AccountEntity(account.getId(), account.getEmail())
+    );
+    return new Account(saved.getId(), saved.getEmail());
+  }
 }

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/account/AccountServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/account/AccountServiceTest.java
@@ -53,4 +53,13 @@ class AccountServiceTest {
 
     assertThat(result).isEmpty();
   }
+
+  @Test
+  void 이메일로_계정을_생성한다() {
+    Account account = accountService.create("new@nextdv.com");
+
+    assertThat(account.getId()).isNotNull();
+    assertThat(account.getEmail()).isEqualTo("new@nextdv.com");
+    assertThat(accountService.findAll()).hasSize(1);
+  }
 }


### PR DESCRIPTION
## 배경
채널 등록 시 userId가 필요하지만 계정 생성 API가 없어 실사용이 불가능한 상태였습니다.

## 변경 사항
- `POST /accounts` 엔드포인트 추가 (201 Created)
- `AccountRepository`에 `save` 메서드 추가
- `AccountService`에 `create(email)` 메서드 추가

## 테스트
- `AccountServiceTest`: 이메일로 계정 생성 테스트 추가

Closes #84