### PR TITLE
fix(exception): GlobalExceptionHandler 누락 예외 처리 및 Request DTO 입력 검증 추가

### DIFF
--- a/api/src/main/java/com/nextdv/api/account/AccountRequest.java
+++ b/api/src/main/java/com/nextdv/api/account/AccountRequest.java
@@ -1,0 +1,18 @@
+package com.nextdv.api.account;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class AccountRequest {
+
+  @NotBlank(message = "이메일은 필수입니다.")
+  @Email(message = "올바른 이메일 형식이어야 합니다.")
+  private String email;
+
+  public AccountRequest() {
+  }
+
+  public String getEmail() {
+    return email;
+  }
+}

--- a/api/src/main/java/com/nextdv/api/channel/ChannelController.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelController.java
@@ -5,6 +5,7 @@ import com.nextdv.domain.channel.Channel;
 import com.nextdv.domain.channel.ChannelService;
 import java.util.List;
 import java.util.UUID;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -27,7 +28,8 @@ public class ChannelController {
   }
 
   @PostMapping
-  public ResponseEntity<ApiResponse<ChannelResponse>> create(@RequestBody ChannelRequest request) {
+  public ResponseEntity<ApiResponse<ChannelResponse>> create(
+      @Valid @RequestBody ChannelRequest request) {
     Channel channel = channelService.create(
         request.getUserId(),
         request.getType(),

--- a/api/src/main/java/com/nextdv/api/channel/ChannelPlatformController.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelPlatformController.java
@@ -3,6 +3,7 @@ package com.nextdv.api.channel;
 import com.nextdv.api.common.ApiResponse;
 import com.nextdv.domain.channel.ChannelPlatform;
 import com.nextdv.domain.channel.ChannelPlatformService;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,7 +23,7 @@ public class ChannelPlatformController {
 
   @PostMapping
   public ResponseEntity<ApiResponse<ChannelPlatformResponse>> subscribe(
-      @RequestBody ChannelPlatformRequest request) {
+      @Valid @RequestBody ChannelPlatformRequest request) {
     ChannelPlatform channelPlatform = channelPlatformService.subscribe(
         request.getChannelId(),
         request.getPlatformId()

--- a/api/src/main/java/com/nextdv/api/channel/ChannelPlatformRequest.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelPlatformRequest.java
@@ -1,11 +1,15 @@
 package com.nextdv.api.channel;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.Getter;
 
 @Getter
 public class ChannelPlatformRequest {
 
+  @NotNull(message = "channelId는 필수입니다.")
   private UUID channelId;
+
+  @NotNull(message = "platformId는 필수입니다.")
   private UUID platformId;
 }

--- a/api/src/main/java/com/nextdv/api/channel/ChannelRequest.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelRequest.java
@@ -1,6 +1,8 @@
 package com.nextdv.api.channel;
 
 import com.nextdv.domain.channel.ChannelType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.UUID;
 import lombok.Getter;
@@ -8,8 +10,15 @@ import lombok.Getter;
 @Getter
 public class ChannelRequest {
 
+  @NotNull(message = "userId는 필수입니다.")
   private UUID userId;
+
+  @NotNull(message = "type은 필수입니다.")
   private ChannelType type;
+
+  @NotBlank(message = "name은 필수입니다.")
   private String name;
+
+  @NotNull(message = "config는 필수입니다.")
   private Map<String, Object> config;
 }

--- a/api/src/main/java/com/nextdv/api/common/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/nextdv/api/common/GlobalExceptionHandler.java
@@ -1,11 +1,17 @@
 package com.nextdv.api.common;
 
 import java.util.NoSuchElementException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -19,9 +25,47 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.fail(e.getMessage()));
   }
 
+  @ExceptionHandler(IllegalStateException.class)
+  public ResponseEntity<ApiResponse<Void>> handleConflict(IllegalStateException e) {
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(ApiResponse.fail(e.getMessage()));
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ApiResponse<Void>> handleNotReadable(HttpMessageNotReadableException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ApiResponse.fail("요청 형식이 올바르지 않습니다."));
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ApiResponse<Void>> handleTypeMismatch(
+      MethodArgumentTypeMismatchException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ApiResponse.fail("요청 파라미터 형식이 올바르지 않습니다."));
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<ApiResponse<Void>> handleMissingParam(
+      MissingServletRequestParameterException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ApiResponse.fail("필수 파라미터가 누락되었습니다: " + e.getParameterName()));
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException e) {
+    String message = e.getBindingResult().getFieldErrors().stream()
+        .map(fe -> fe.getDefaultMessage())
+        .findFirst()
+        .orElse("입력값이 올바르지 않습니다.");
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.fail(message));
+  }
+
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+    log.error(
+        "예상치 못한 오류 발생",
+        e
+    );
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .body(ApiResponse.fail(e.getMessage()));
+        .body(ApiResponse.fail("서버 오류가 발생했습니다."));
   }
 }


### PR DESCRIPTION
## 배경
GlobalExceptionHandler가 3가지 예외만 처리해 클라이언트 오류가 500으로 응답되거나
내부 Spring 에러 메시지가 그대로 노출되는 문제가 있었습니다.
Request DTO에 Valid가 없어 null/빈값/형식 오류 입력이 서비스까지 전달됐습니다.

## 변경 사항
- `GlobalExceptionHandler`에 핸들러 5개 추가
  - `IllegalStateException` → 409
  - `HttpMessageNotReadableException` (잘못된 JSON, 잘못된 enum) → 400
  - `MethodArgumentTypeMismatchException` (잘못된 UUID 형식) → 400
  - `MissingServletRequestParameterException` (필수 파라미터 누락) → 400
  - `MethodArgumentNotValidException` (Valid 실패) → 400
- 500 핸들러 내부 메시지 노출 제거 → "서버 오류가 발생했습니다." 고정
- `AccountRequest`, `ChannelRequest`, `ChannelPlatformRequest` Bean Validation 추가
- `ChannelController`, `ChannelPlatformController`에 `Valid` 추가

Closes #86