### PR TITLE
fix(account): 계정 생성 시 이메일 검증 및 중복 방지 추가

### DIFF
--- a/domain/src/main/java/com/nextdv/domain/account/AccountRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/account/AccountRepository.java
@@ -5,4 +5,8 @@ import java.util.List;
 public interface AccountRepository {
 
   List<Account> findAll();
+
+  Account save(Account account);
+
+  boolean existsByEmail(String email);
 }

--- a/domain/src/main/java/com/nextdv/domain/account/AccountService.java
+++ b/domain/src/main/java/com/nextdv/domain/account/AccountService.java
@@ -1,6 +1,7 @@
 package com.nextdv.domain.account;
 
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,5 +13,15 @@ public class AccountService {
 
   public List<Account> findAll() {
     return accountRepository.findAll();
+  }
+
+  public Account create(String email) {
+    if (email == null || email.isBlank()) {
+      throw new IllegalArgumentException("이메일은 필수입니다.");
+    }
+    if (accountRepository.existsByEmail(email)) {
+      throw new IllegalStateException("이미 사용 중인 이메일입니다.");
+    }
+    return accountRepository.save(new Account(UUID.randomUUID(), email));
   }
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountJpaRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AccountJpaRepository
     extends
       JpaRepository<AccountEntity, UUID> {
+
+  boolean existsByEmail(String email);
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountRepositoryImpl.java
@@ -18,4 +18,17 @@ public class AccountRepositoryImpl implements AccountRepository {
         .map(entity -> new Account(entity.getId(), entity.getEmail()))
         .toList();
   }
+
+  @Override
+  public Account save(Account account) {
+    AccountEntity saved = accountJpaRepository.save(
+        new AccountEntity(account.getId(), account.getEmail())
+    );
+    return new Account(saved.getId(), saved.getEmail());
+  }
+
+  @Override
+  public boolean existsByEmail(String email) {
+    return accountJpaRepository.existsByEmail(email);
+  }
 }

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/account/AccountServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/account/AccountServiceTest.java
@@ -1,6 +1,7 @@
 package com.nextdv.infrastructure.account;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.nextdv.domain.account.Account;
 import com.nextdv.domain.account.AccountService;
@@ -52,5 +53,19 @@ class AccountServiceTest {
     List<Account> result = accountService.findAll();
 
     assertThat(result).isEmpty();
+  }
+
+  @Test
+  void 이메일이_blank이면_예외가_발생한다() {
+    assertThatThrownBy(() -> accountService.create(""))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void 중복_이메일로_생성하면_예외가_발생한다() {
+    accountService.create("dup@nextdv.com");
+
+    assertThatThrownBy(() -> accountService.create("dup@nextdv.com"))
+        .isInstanceOf(IllegalStateException.class);
   }
 }


### PR DESCRIPTION
## 배경
AccountService.create()에 이메일 검증이 없어 blank 이메일 저장 및
중복 이메일 시 DB unique 제약 위반으로 500이 발생했습니다.

## 변경 사항
- `AccountService.create()`에 blank 이메일 검증 추가 (→ 400)
- `AccountService.create()`에 중복 이메일 검증 추가 (→ 409)
- `AccountRepository`, `AccountJpaRepository`, `AccountRepositoryImpl`에 `existsByEmail` 추가

## 테스트
- `AccountServiceTest`: blank 이메일 예외, 중복 이메일 예외 테스트 추가

Closes #87