### PR TITLE
fix(channel): 채널 삭제 예외 404 수정 및 구독 시 채널/플랫폼 존재 확인 추가

### DIFF
--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformService.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformService.java
@@ -1,6 +1,8 @@
 package com.nextdv.domain.channel;
 
+import com.nextdv.domain.platform.PlatformRepository;
 import java.time.Instant;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,8 +12,16 @@ import org.springframework.stereotype.Service;
 public class ChannelPlatformService {
 
   private final ChannelPlatformRepository channelPlatformRepository;
+  private final ChannelRepository channelRepository;
+  private final PlatformRepository platformRepository;
 
   public ChannelPlatform subscribe(UUID channelId, UUID platformId) {
+    channelRepository
+        .findById(channelId)
+        .orElseThrow(() -> new NoSuchElementException("채널을 찾을 수 없습니다."));
+    platformRepository
+        .findById(platformId)
+        .orElseThrow(() -> new NoSuchElementException("플랫폼을 찾을 수 없습니다."));
     if (channelPlatformRepository.existsByChannelIdAndPlatformId(
         channelId,
         platformId

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelService.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelService.java
@@ -3,6 +3,7 @@ package com.nextdv.domain.channel;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,9 @@ public class ChannelService {
   }
 
   private void validateConfig(ChannelType type, Map<String, Object> config) {
+    if (config == null) {
+      throw new IllegalArgumentException("config는 필수입니다.");
+    }
     switch (type) {
       case EMAIL -> {
         Object address = config.get("address");
@@ -56,7 +60,7 @@ public class ChannelService {
   public void delete(UUID id) {
     Channel channel = channelRepository
         .findById(id)
-        .orElseThrow(() -> new IllegalArgumentException("채널을 찾을 수 없습니다."));
+        .orElseThrow(() -> new NoSuchElementException("채널을 찾을 수 없습니다."));
     Channel deleted = new Channel(
         channel.getId(),
         channel.getUserId(),

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelPlatformServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelPlatformServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.nextdv.domain.channel.ChannelPlatform;
 import com.nextdv.domain.channel.ChannelPlatformService;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,6 +65,18 @@ class ChannelPlatformServiceTest {
     assertThat(entity.getChannelId()).isEqualTo(channelId);
     assertThat(entity.getPlatformId()).isEqualTo(platformId);
     assertThat(entity.getDeletedAt()).isNull();
+  }
+
+  @Test
+  void 존재하지_않는_채널ID로_구독하면_예외가_발생한다() {
+    assertThatThrownBy(
+        () -> channelPlatformService.subscribe(
+            UUID.randomUUID(),
+            UUID.randomUUID()
+        )
+    )
+        .isInstanceOf(NoSuchElementException.class)
+        .hasMessage("채널을 찾을 수 없습니다.");
   }
 
   @Test

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelPlatformServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelPlatformServiceTest.java
@@ -5,6 +5,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.nextdv.domain.channel.ChannelPlatform;
 import com.nextdv.domain.channel.ChannelPlatformService;
+import com.nextdv.domain.platform.ServiceCategory;
+import com.nextdv.infrastructure.platform.PlatformEntity;
+import com.nextdv.infrastructure.platform.PlatformJpaRepository;
+import com.nextdv.infrastructure.platform.PlatformRepositoryImpl;
+import java.time.Instant;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -20,7 +26,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
-@Import({ChannelPlatformRepositoryImpl.class, ChannelPlatformService.class})
+@Import({
+    ChannelPlatformRepositoryImpl.class,
+    ChannelPlatformService.class,
+    ChannelRepositoryImpl.class,
+    PlatformRepositoryImpl.class
+})
 @Testcontainers
 class ChannelPlatformServiceTest {
 
@@ -32,12 +43,38 @@ class ChannelPlatformServiceTest {
   private ChannelPlatformJpaRepository channelPlatformJpaRepository;
 
   @Autowired
+  private ChannelJpaRepository channelJpaRepository;
+
+  @Autowired
+  private PlatformJpaRepository platformJpaRepository;
+
+  @Autowired
   private ChannelPlatformService channelPlatformService;
+
+  private UUID savedChannelId() {
+    Instant now = Instant.now();
+    ChannelEntity channel = new ChannelEntity(
+        UUID.randomUUID(), UUID.randomUUID(), ChannelTypeEntity.SLACK, "테스트 채널",
+        Map.of(
+            "url",
+            "https://hooks.slack.com/test"
+        ), now, now, null
+    );
+    return channelJpaRepository.save(channel).getId();
+  }
+
+  private UUID savedPlatformId() {
+    PlatformEntity platform = new PlatformEntity(
+        UUID.randomUUID(), "테스트 플랫폼", ServiceCategory.OTHER,
+        "https://example.com/health", 5000, 2000, null, true
+    );
+    return platformJpaRepository.save(platform).getId();
+  }
 
   @Test
   void 채널과_플랫폼을_구독하면_저장하고_반환한다() {
-    UUID channelId = UUID.randomUUID();
-    UUID platformId = UUID.randomUUID();
+    UUID channelId = savedChannelId();
+    UUID platformId = savedPlatformId();
 
     ChannelPlatform result = channelPlatformService.subscribe(
         channelId,
@@ -52,8 +89,8 @@ class ChannelPlatformServiceTest {
 
   @Test
   void 구독하면_DB에_실제로_저장된다() {
-    UUID channelId = UUID.randomUUID();
-    UUID platformId = UUID.randomUUID();
+    UUID channelId = savedChannelId();
+    UUID platformId = savedPlatformId();
 
     ChannelPlatform result = channelPlatformService.subscribe(
         channelId,
@@ -80,9 +117,23 @@ class ChannelPlatformServiceTest {
   }
 
   @Test
+  void 존재하지_않는_플랫폼ID로_구독하면_예외가_발생한다() {
+    UUID channelId = savedChannelId();
+
+    assertThatThrownBy(
+        () -> channelPlatformService.subscribe(
+            channelId,
+            UUID.randomUUID()
+        )
+    )
+        .isInstanceOf(NoSuchElementException.class)
+        .hasMessage("플랫폼을 찾을 수 없습니다.");
+  }
+
+  @Test
   void 이미_구독된_채널_플랫폼을_다시_구독하면_예외가_발생한다() {
-    UUID channelId = UUID.randomUUID();
-    UUID platformId = UUID.randomUUID();
+    UUID channelId = savedChannelId();
+    UUID platformId = savedPlatformId();
     channelPlatformService.subscribe(
         channelId,
         platformId

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelServiceTest.java
@@ -9,6 +9,7 @@ import com.nextdv.domain.channel.ChannelType;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -133,7 +134,7 @@ class ChannelServiceTest {
     UUID channelId = UUID.randomUUID();
 
     assertThatThrownBy(() -> channelService.delete(channelId))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(NoSuchElementException.class)
         .hasMessage("채널을 찾을 수 없습니다.");
   }
 


### PR DESCRIPTION
## 배경
1. `ChannelService.delete()`가 존재하지 않는 채널에 400을 반환했으나 의미상 404여야 합니다.
2. `ChannelPlatformService.subscribe()`에서 channelId/platformId 존재 여부를 확인하지 않아
   존재하지 않는 ID로도 구독 레코드가 생성됐습니다. (DB에 FK 제약 없음)

## 변경 사항
- `ChannelService.delete()` 예외를 `NoSuchElementException`(→ 404)으로 교체
- `ChannelService.validateConfig()`에 config null guard 추가
- `ChannelPlatformService`에 `ChannelRepository`, `PlatformRepository` 주입
- `subscribe()` 호출 전 channelId, platformId 존재 확인 추가 (→ 404)

## 테스트
- `ChannelServiceTest`: 삭제 예외 타입 `NoSuchElementException`으로 수정
- `ChannelPlatformServiceTest`: 존재하지 않는 채널/플랫폼 구독 예외 테스트 추가

Closes #88