### PR TITLE
fix(account): 계정 생성 시 이메일 검증 및 중복 방지 추가

### DIFF
--- a/domain/src/main/java/com/nextdv/domain/account/AccountRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/account/AccountRepository.java
@@ -7,4 +7,6 @@ public interface AccountRepository {
   List<Account> findAll();
 
   Account save(Account account);
+
+  boolean existsByEmail(String email);
 }

--- a/domain/src/main/java/com/nextdv/domain/account/AccountService.java
+++ b/domain/src/main/java/com/nextdv/domain/account/AccountService.java
@@ -16,6 +16,12 @@ public class AccountService {
   }
 
   public Account create(String email) {
+    if (email == null || email.isBlank()) {
+      throw new IllegalArgumentException("이메일은 필수입니다.");
+    }
+    if (accountRepository.existsByEmail(email)) {
+      throw new IllegalStateException("이미 사용 중인 이메일입니다.");
+    }
     return accountRepository.save(new Account(UUID.randomUUID(), email));
   }
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountJpaRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AccountJpaRepository
     extends
       JpaRepository<AccountEntity, UUID> {
+
+  boolean existsByEmail(String email);
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.nextdv.domain.account.Account;
 import com.nextdv.domain.account.AccountRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -21,9 +22,17 @@ public class AccountRepositoryImpl implements AccountRepository {
 
   @Override
   public Account save(Account account) {
-    AccountEntity saved = accountJpaRepository.save(
-        new AccountEntity(account.getId(), account.getEmail())
-    );
-    return new Account(saved.getId(), saved.getEmail());
+    try {
+      AccountEntity saved = accountJpaRepository
+          .save(new AccountEntity(account.getId(), account.getEmail()));
+      return new Account(saved.getId(), saved.getEmail());
+    } catch (DataIntegrityViolationException e) {
+      throw new IllegalStateException("이미 사용 중인 이메일입니다.");
+    }
+  }
+
+  @Override
+  public boolean existsByEmail(String email) {
+    return accountJpaRepository.existsByEmail(email);
   }
 }

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/account/AccountServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/account/AccountServiceTest.java
@@ -1,6 +1,7 @@
 package com.nextdv.infrastructure.account;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.nextdv.domain.account.Account;
 import com.nextdv.domain.account.AccountService;
@@ -25,9 +26,7 @@ class AccountServiceTest {
 
   @Container
   @ServiceConnection
-  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
-      "postgres:16-alpine"
-  );
+  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
 
   @Autowired
   private AccountJpaRepository jpaRepository;
@@ -61,5 +60,19 @@ class AccountServiceTest {
     assertThat(account.getId()).isNotNull();
     assertThat(account.getEmail()).isEqualTo("new@nextdv.com");
     assertThat(accountService.findAll()).hasSize(1);
+  }
+
+  @Test
+  void 이메일이_blank이면_예외가_발생한다() {
+    assertThatThrownBy(() -> accountService.create(""))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void 중복_이메일로_생성하면_예외가_발생한다() {
+    accountService.create("dup@nextdv.com");
+
+    assertThatThrownBy(() -> accountService.create("dup@nextdv.com"))
+        .isInstanceOf(IllegalStateException.class);
   }
 }


### PR DESCRIPTION
## 변경 사항

- `AccountService.create()`에 이메일 blank 검증 추가 → `IllegalArgumentException` (400)
- `AccountService.create()`에 중복 이메일 검증 추가 → `IllegalStateException` (409)
- `AccountRepository`, `AccountJpaRepository`, `AccountRepositoryImpl`에 `existsByEmail()` 추가

## 테스트

`AccountServiceTest` — 5개 테스트 통과
- 저장된_계정을_전체_조회한다
- 계정이_없으면_빈_목록을_반환한다
- 이메일로_계정을_생성한다
- 이메일이_blank이면_예외가_발생한다 (NEW)
- 중복_이메일로_생성하면_예외가_발생한다 (NEW)

Closes #88