### PR TITLE
fix(swagger): Cloudflare 환경에서 Swagger 서버 URL https 표시 수정

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -22,6 +22,9 @@ spring:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true
 
+server:
+  forward-headers-strategy: framework
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html


### PR DESCRIPTION
## 문제

Cloudflare → Traefik → Spring Boot 구조에서 Swagger UI의 서버 URL이 `http://`로 표시됨.
브라우저가 HTTPS 페이지에서 HTTP API 요청을 차단해 CORS처럼 보이는 에러 발생.

## 원인

Spring Boot가 Cloudflare가 전달하는 `X-Forwarded-Proto: https` 헤더를 읽지 않아
자신이 HTTP로 동작 중이라 인식.

## 변경 사항

`api/src/main/resources/application.yml`에 아래 한 줄 추가:

```yaml
server:
  forward-headers-strategy: framework
```

Spring이 프록시(Cloudflare)가 전달하는 `X-Forwarded-Proto` 헤더를 신뢰해
Swagger UI 서버 URL이 `https://heartbeat.chapchu.site`로 올바르게 표시됨.

Closes #96