### PR TITLE
fix(swagger): Traefik 환경에서 Swagger 서버 URL https 고정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,5 +53,7 @@ jobs:
             sudo kubectl apply -f ~/heartbeat-k3s/k3s/service.yaml
             sudo kubectl apply -f ~/heartbeat-k3s/k3s/deployment.yaml
             sudo kubectl apply -f ~/heartbeat-k3s/k3s/ingress.yaml
+            sudo kubectl patch secret heartbeat-secret -n heartbeat \
+              --patch='{"stringData":{"APP_SWAGGER_SERVER_URL":"${{ secrets.APP_SWAGGER_SERVER_URL }}"}}'
             sudo kubectl rollout restart deployment/heartbeat -n heartbeat
             sudo kubectl rollout status deployment/heartbeat -n heartbeat --timeout=120s

--- a/api/src/main/java/com/nextdv/api/common/SwaggerConfig.java
+++ b/api/src/main/java/com/nextdv/api/common/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package com.nextdv.api.common;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI(@Value("${app.swagger-server-url:}") String serverUrl) {
+    if (serverUrl.isBlank()) {
+      return new OpenAPI();
+    }
+    return new OpenAPI().servers(List.of(new Server().url(serverUrl)));
+  }
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -22,8 +22,8 @@ spring:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true
 
-server:
-  forward-headers-strategy: framework
+app:
+  swagger-server-url: ${APP_SWAGGER_SERVER_URL:}
 
 springdoc:
   swagger-ui:

--- a/k3s/secret.template.yaml
+++ b/k3s/secret.template.yaml
@@ -8,7 +8,8 @@
 #   --from-literal=MAIL_HOST=smtp.gmail.com \
 #   --from-literal=MAIL_PORT=587 \
 #   --from-literal=MAIL_USERNAME=<EMAIL> \
-#   --from-literal=MAIL_PASSWORD=<APP_PASSWORD>
+#   --from-literal=MAIL_PASSWORD=<APP_PASSWORD> \
+#   --from-literal=APP_SWAGGER_SERVER_URL=https://heartbeat.chapchu.site
 apiVersion: v1
 kind: Secret
 metadata:
@@ -23,3 +24,4 @@ stringData:
   MAIL_PORT: ""
   MAIL_USERNAME: ""
   MAIL_PASSWORD: ""
+  APP_SWAGGER_SERVER_URL: ""


### PR DESCRIPTION
## 문제

Swagger UI에서 서버 URL이 `http://`로 표시되어 Try it out 사용 불가 (Mixed Content 오류).

## 원인

PR #97의 `forward-headers-strategy` 방식 미동작.  
k3s Traefik이 Cloudflare의 `X-Forwarded-Proto: https` 헤더를 Spring Boot까지 전달하지 않음.

## 변경 사항

| 파일 | 내용 |
|---|---|
| `SwaggerConfig.java` (신규) | 환경변수로 OpenAPI 서버 URL 주입 |
| `application.yml` | `app.swagger-server-url` 프로퍼티 추가 |
| `k3s/deployment.yaml` | 하드코딩 env 제거 → secret에서 주입 |
| `k3s/secret.template.yaml` | `APP_SWAGGER_SERVER_URL` 항목 추가 |
| `.github/workflows/deploy.yml` | 배포 시 GitHub secret → k8s secret 자동 주입 스텝 추가 |

## 배포 전 GitHub Secret 등록 필요

[Settings → Secrets → Actions](https://github.com/NEXTDV/heartbeat-server/settings/secrets/actions) 에서 추가:

| Name | Value |
|---|---|
| `APP_SWAGGER_SERVER_URL` | `https://heartbeat.chapchu.site` |

등록 후 PR 머지하면 자동으로 배포 및 적용됩니다.

Closes #98