### PR TITLE
fix(config): open-in-view false 설정

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: update
     properties:


### PR DESCRIPTION
## 변경 내용

`spring.jpa.open-in-view: false` 설정 추가.

## 배경

Spring Boot의 기본값은 `open-in-view: true`로, HTTP 요청 시작부터 응답 완료까지 DB 커넥션을 계속 유지함.
REST API에서는 View 레이어가 없으므로 이 동작이 불필요하며, 커넥션 풀을 낭비하는 원인이 됨.

## 영향

없음. 기존 코드에서 지연 로딩을 Controller/View 레이어에서 사용하는 곳이 없음.

Closes #100