### PR TITLE
feat(entity): JPA Entity에 FK 제약 추가

### DIFF
--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelEntity.java
@@ -1,25 +1,25 @@
 package com.nextdv.infrastructure.channel;
 
+import com.nextdv.infrastructure.account.AccountEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "channels")
 @Getter
-@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class ChannelEntity {
 
   @Id
@@ -27,6 +27,10 @@ public class ChannelEntity {
 
   @Column(name = "user_id", nullable = false)
   private UUID userId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", insertable = false, updatable = false)
+  private AccountEntity account;
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
@@ -48,4 +52,25 @@ public class ChannelEntity {
   @Column(name = "deleted_at")
   private Instant deletedAt;
 
+  protected ChannelEntity() {
+  }
+
+  public ChannelEntity(
+      UUID id,
+      UUID userId,
+      ChannelTypeEntity type,
+      String name,
+      Map<String, Object> config,
+      Instant createdAt,
+      Instant updatedAt,
+      Instant deletedAt) {
+    this.id = id;
+    this.userId = userId;
+    this.type = type;
+    this.name = name;
+    this.config = config;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.deletedAt = deletedAt;
+  }
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformEntity.java
@@ -1,8 +1,12 @@
 package com.nextdv.infrastructure.channel;
 
+import com.nextdv.infrastructure.platform.PlatformEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.UUID;
@@ -19,8 +23,16 @@ public class ChannelPlatformEntity {
   @Column(name = "channel_id", nullable = false)
   private UUID channelId;
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "channel_id", insertable = false, updatable = false)
+  private ChannelEntity channel;
+
   @Column(name = "platform_id", nullable = false)
   private UUID platformId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "platform_id", insertable = false, updatable = false)
+  private PlatformEntity platform;
 
   @Column(name = "created_at", nullable = false)
   private Instant createdAt;

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogEntity.java
@@ -1,10 +1,14 @@
 package com.nextdv.infrastructure.healthcheck;
 
+import com.nextdv.infrastructure.platform.PlatformEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.UUID;
@@ -22,6 +26,10 @@ public class HealthCheckLogEntity {
 
   @Column(name = "platform_id", nullable = false)
   private UUID platformId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "platform_id", insertable = false, updatable = false)
+  private PlatformEntity platform;
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelPlatformServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelPlatformServiceTest.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.nextdv.domain.channel.ChannelPlatform;
 import com.nextdv.domain.channel.ChannelPlatformService;
 import com.nextdv.domain.platform.ServiceCategory;
+import com.nextdv.infrastructure.account.AccountEntity;
+import com.nextdv.infrastructure.account.AccountJpaRepository;
 import com.nextdv.infrastructure.platform.PlatformEntity;
 import com.nextdv.infrastructure.platform.PlatformJpaRepository;
 import com.nextdv.infrastructure.platform.PlatformRepositoryImpl;
@@ -46,17 +48,22 @@ class ChannelPlatformServiceTest {
   private ChannelJpaRepository channelJpaRepository;
 
   @Autowired
+  private AccountJpaRepository accountJpaRepository;
+
+  @Autowired
   private PlatformJpaRepository platformJpaRepository;
 
   @Autowired
   private ChannelPlatformService channelPlatformService;
 
   private UUID savedChannelId() {
+    UUID userId = UUID.randomUUID();
+    accountJpaRepository.save(new AccountEntity(userId, userId + "@test.com"));
     Instant now = Instant.now();
     ChannelEntity entity = channelJpaRepository.save(
         new ChannelEntity(
             UUID.randomUUID(),
-            UUID.randomUUID(),
+            userId,
             ChannelTypeEntity.SLACK,
             "슬랙",
             Map.of(

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/channel/ChannelServiceTest.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.nextdv.domain.channel.Channel;
 import com.nextdv.domain.channel.ChannelService;
 import com.nextdv.domain.channel.ChannelType;
+import com.nextdv.infrastructure.account.AccountEntity;
+import com.nextdv.infrastructure.account.AccountJpaRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -36,11 +38,19 @@ class ChannelServiceTest {
   private ChannelJpaRepository channelJpaRepository;
 
   @Autowired
+  private AccountJpaRepository accountJpaRepository;
+
+  @Autowired
   private ChannelService channelService;
+
+  private void saveAccount(UUID userId) {
+    accountJpaRepository.save(new AccountEntity(userId, userId + "@test.com"));
+  }
 
   @Test
   void 채널을_생성하면_저장하고_반환한다() {
     UUID userId = UUID.randomUUID();
+    saveAccount(userId);
     Map<String, Object> config = Map.of(
         "url",
         "https://hooks.slack.com/example"
@@ -62,6 +72,7 @@ class ChannelServiceTest {
   @Test
   void userId로_채널_목록을_조회한다() {
     UUID userId = UUID.randomUUID();
+    saveAccount(userId);
     Instant now = Instant.now();
     channelJpaRepository.save(
         new ChannelEntity(
@@ -84,6 +95,7 @@ class ChannelServiceTest {
   @Test
   void 채널을_삭제하면_deletedAt이_설정된다() {
     UUID userId = UUID.randomUUID();
+    saveAccount(userId);
     Channel created = channelService.create(
         userId,
         ChannelType.EMAIL,
@@ -103,6 +115,7 @@ class ChannelServiceTest {
   @Test
   void 삭제된_채널은_목록_조회에서_제외된다() {
     UUID userId = UUID.randomUUID();
+    saveAccount(userId);
     Channel active = channelService.create(
         userId,
         ChannelType.SLACK,

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogServiceTest.java
@@ -6,6 +6,9 @@ import com.nextdv.domain.common.UuidV7;
 import com.nextdv.domain.healthcheck.HealthCheckLog;
 import com.nextdv.domain.healthcheck.HealthCheckLogService;
 import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.ServiceCategory;
+import com.nextdv.infrastructure.platform.PlatformEntity;
+import com.nextdv.infrastructure.platform.PlatformJpaRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -35,7 +38,20 @@ class HealthCheckLogServiceTest {
   private HealthCheckLogJpaRepository jpaRepository;
 
   @Autowired
+  private PlatformJpaRepository platformJpaRepository;
+
+  @Autowired
   private HealthCheckLogService healthCheckLogService;
+
+  private UUID savedPlatformId() {
+    UUID id = UUID.randomUUID();
+    platformJpaRepository.save(
+        new PlatformEntity(
+            id, "테스트", ServiceCategory.OTHER, "https://example.com/health", 3000, 1000, null, true
+        )
+    );
+    return id;
+  }
 
   @Test
   void 로그가_없으면_빈_Optional을_반환한다() {
@@ -48,7 +64,7 @@ class HealthCheckLogServiceTest {
 
   @Test
   void 최신_로그를_반환한다() {
-    UUID platformId = UUID.randomUUID();
+    UUID platformId = savedPlatformId();
     Instant older = Instant.now().minusSeconds(60);
     Instant newer = Instant.now();
     jpaRepository.save(
@@ -78,7 +94,7 @@ class HealthCheckLogServiceTest {
 
   @Test
   void platformId로_로그_목록을_조회한다() {
-    UUID platformId = UUID.randomUUID();
+    UUID platformId = savedPlatformId();
     Instant now = Instant.now();
     jpaRepository.save(
         new HealthCheckLogEntity(
@@ -99,8 +115,8 @@ class HealthCheckLogServiceTest {
 
   @Test
   void 다른_플랫폼_로그는_조회되지_않는다() {
-    UUID platformId = UUID.randomUUID();
-    UUID otherPlatformId = UUID.randomUUID();
+    UUID platformId = savedPlatformId();
+    UUID otherPlatformId = savedPlatformId();
     Instant now = Instant.now();
     jpaRepository.save(
         new HealthCheckLogEntity(

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollNotificationTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollNotificationTest.java
@@ -6,6 +6,8 @@ import com.nextdv.domain.channel.ChannelRepository;
 import com.nextdv.domain.healthcheck.ServiceStatus;
 import com.nextdv.domain.platform.Platform;
 import com.nextdv.domain.platform.ServiceCategory;
+import com.nextdv.infrastructure.account.AccountEntity;
+import com.nextdv.infrastructure.account.AccountJpaRepository;
 import com.nextdv.infrastructure.channel.ChannelEntity;
 import com.nextdv.infrastructure.channel.ChannelJpaRepository;
 import com.nextdv.infrastructure.channel.ChannelPlatformEntity;
@@ -15,6 +17,8 @@ import com.nextdv.infrastructure.channel.ChannelTypeEntity;
 import com.nextdv.infrastructure.notification.FakeDiscordSender;
 import com.nextdv.infrastructure.notification.FakeEmailSender;
 import com.nextdv.infrastructure.notification.FakeSlackSender;
+import com.nextdv.infrastructure.platform.PlatformEntity;
+import com.nextdv.infrastructure.platform.PlatformJpaRepository;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
@@ -47,12 +51,31 @@ class HealthCheckPollNotificationTest {
   private ChannelPlatformJpaRepository channelPlatformJpaRepository;
 
   @Autowired
+  private AccountJpaRepository accountJpaRepository;
+
+  @Autowired
+  private PlatformJpaRepository platformJpaRepository;
+
+  @Autowired
   private ChannelRepository channelRepository;
 
   private FakeEmailSender fakeEmailSender;
   private FakeSlackSender fakeSlackSender;
   private FakeDiscordSender fakeDiscordSender;
   private HealthCheckPollService service;
+
+  private void saveAccount(UUID userId) {
+    accountJpaRepository.save(new AccountEntity(userId, userId + "@test.com"));
+  }
+
+  private void savePlatform(UUID platformId) {
+    platformJpaRepository.save(
+        new PlatformEntity(
+            platformId, "테스트", ServiceCategory.OTHER, "https://example.com/health", 3000, 1000,
+            null, true
+        )
+    );
+  }
 
   @BeforeEach
   void setUp() {
@@ -68,17 +91,20 @@ class HealthCheckPollNotificationTest {
   void 상태변화_시_이메일_채널에_알림이_발송된다() {
     UUID platformId = UUID.randomUUID();
     UUID channelId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
     Instant now = Instant.now();
 
+    saveAccount(userId);
     channelJpaRepository.save(
         new ChannelEntity(
-            channelId, UUID.randomUUID(), ChannelTypeEntity.EMAIL,
+            channelId, userId, ChannelTypeEntity.EMAIL,
             "이메일", Map.of(
                 "address",
                 "user@example.com"
             ), now, now, null
         )
     );
+    savePlatform(platformId);
     channelPlatformJpaRepository.save(
         new ChannelPlatformEntity(UUID.randomUUID(), channelId, platformId, now)
     );
@@ -133,17 +159,20 @@ class HealthCheckPollNotificationTest {
   void 소프트삭제된_구독은_알림이_발송되지_않는다() {
     UUID platformId = UUID.randomUUID();
     UUID channelId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
     Instant now = Instant.now();
 
+    saveAccount(userId);
     channelJpaRepository.save(
         new ChannelEntity(
-            channelId, UUID.randomUUID(), ChannelTypeEntity.EMAIL,
+            channelId, userId, ChannelTypeEntity.EMAIL,
             "이메일", Map.of(
                 "address",
                 "user@example.com"
             ), now, now, null
         )
     );
+    savePlatform(platformId);
     channelPlatformJpaRepository.save(
         new ChannelPlatformEntity(UUID.randomUUID(), channelId, platformId, now, now)
     );
@@ -166,17 +195,20 @@ class HealthCheckPollNotificationTest {
   void 이미_발송된_상태에서_같은_상태가_유지되면_추가_알림이_발송되지_않는다() {
     UUID platformId = UUID.randomUUID();
     UUID channelId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
     Instant now = Instant.now();
 
+    saveAccount(userId);
     channelJpaRepository.save(
         new ChannelEntity(
-            channelId, UUID.randomUUID(), ChannelTypeEntity.EMAIL,
+            channelId, userId, ChannelTypeEntity.EMAIL,
             "이메일", Map.of(
                 "address",
                 "user@example.com"
             ), now, now, null
         )
     );
+    savePlatform(platformId);
     channelPlatformJpaRepository.save(
         new ChannelPlatformEntity(UUID.randomUUID(), channelId, platformId, now)
     );
@@ -204,17 +236,20 @@ class HealthCheckPollNotificationTest {
   void 상태변화_시_Slack_채널에_알림이_발송된다() {
     UUID platformId = UUID.randomUUID();
     UUID channelId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
     Instant now = Instant.now();
 
+    saveAccount(userId);
     channelJpaRepository.save(
         new ChannelEntity(
-            channelId, UUID.randomUUID(), ChannelTypeEntity.SLACK,
+            channelId, userId, ChannelTypeEntity.SLACK,
             "슬랙", Map.of(
                 "url",
                 "https://hooks.slack.com/test"
             ), now, now, null
         )
     );
+    savePlatform(platformId);
     channelPlatformJpaRepository.save(
         new ChannelPlatformEntity(UUID.randomUUID(), channelId, platformId, now)
     );
@@ -237,17 +272,20 @@ class HealthCheckPollNotificationTest {
   void 상태변화_시_Discord_채널에_알림이_발송된다() {
     UUID platformId = UUID.randomUUID();
     UUID channelId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
     Instant now = Instant.now();
 
+    saveAccount(userId);
     channelJpaRepository.save(
         new ChannelEntity(
-            channelId, UUID.randomUUID(), ChannelTypeEntity.DISCORD,
+            channelId, userId, ChannelTypeEntity.DISCORD,
             "디스코드", Map.of(
                 "url",
                 "https://discord.com/api/webhooks/test"
             ), now, now, null
         )
     );
+    savePlatform(platformId);
     channelPlatformJpaRepository.save(
         new ChannelPlatformEntity(UUID.randomUUID(), channelId, platformId, now)
     );


### PR DESCRIPTION
Closes #101

## 개요

JPA Entity에 `@ManyToOne` + `@JoinColumn(insertable=false, updatable=false)` 패턴으로 FK 제약을 추가합니다.

기존 UUID 필드는 그대로 유지하고 조회 전용 연관관계 필드를 옆에 추가하는 방식이라, 기존 Service/Repository 코드를 변경하지 않아도 됩니다. DB를 재생성하면 `ddl-auto: update`가 Entity 기반으로 테이블을 새로 만들면서 FK도 함께 생성됩니다.

## 변경 내용

### Entity 3개 수정

| Entity | 추가된 FK |
|---|---|
| `ChannelEntity` | `user_id → accounts(id)` |
| `HealthCheckLogEntity` | `platform_id → platforms(id)` |
| `ChannelPlatformEntity` | `channel_id → channels(id)`, `platform_id → platforms(id)` |

### 테스트 4개 수정

FK 제약이 @DataJpaTest 스키마에도 적용되어 기존 테스트가 parent row 없이 child row를 저장하면 FK 위반이 발생합니다. 각 테스트에서 child entity 저장 전에 parent entity(AccountEntity, PlatformEntity)를 먼저 저장하도록 수정했습니다.

| 테스트 | 수정 내용 |
|---|---|
| `ChannelServiceTest` | 채널 생성 전 `AccountEntity` 저장 |
| `ChannelPlatformServiceTest` | `savedChannelId()` 내 `AccountEntity` 먼저 저장 |
| `HealthCheckLogServiceTest` | 로그 저장 전 `PlatformEntity` 저장 |
| `HealthCheckPollNotificationTest` | 채널/구독 저장 전 `AccountEntity` + `PlatformEntity` 저장 |

## 적용 시점

DB를 재생성(postgres 파드 재배포)하면 FK가 실제 DB에 반영됩니다. 재배포 전까지는 기존 데이터에 영향 없습니다.