### PR TITLE
feat(deliverylog): delivery_logs 테이블 및 알림 발송 이력 저장

### DIFF
--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformRepository.java
@@ -1,5 +1,6 @@
 package com.nextdv.domain.channel;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ChannelPlatformRepository {
@@ -7,4 +8,6 @@ public interface ChannelPlatformRepository {
   ChannelPlatform save(ChannelPlatform channelPlatform);
 
   boolean existsByChannelIdAndPlatformId(UUID channelId, UUID platformId);
+
+  Optional<ChannelPlatform> findByChannelIdAndPlatformId(UUID channelId, UUID platformId);
 }

--- a/domain/src/main/java/com/nextdv/domain/deliverylog/DeliveryLog.java
+++ b/domain/src/main/java/com/nextdv/domain/deliverylog/DeliveryLog.java
@@ -1,0 +1,16 @@
+package com.nextdv.domain.deliverylog;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeliveryLog {
+
+  private final UUID id;
+  private final UUID channelPlatformId;
+  private final DeliveryStatus status;
+  private final Instant deliveredAt;
+}

--- a/domain/src/main/java/com/nextdv/domain/deliverylog/DeliveryLogRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/deliverylog/DeliveryLogRepository.java
@@ -1,0 +1,6 @@
+package com.nextdv.domain.deliverylog;
+
+public interface DeliveryLogRepository {
+
+  DeliveryLog save(DeliveryLog log);
+}

--- a/domain/src/main/java/com/nextdv/domain/deliverylog/DeliveryStatus.java
+++ b/domain/src/main/java/com/nextdv/domain/deliverylog/DeliveryStatus.java
@@ -1,0 +1,5 @@
+package com.nextdv.domain.deliverylog;
+
+public enum DeliveryStatus {
+  PENDING, SUCCESS, FAILED
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformJpaRepository.java
@@ -1,9 +1,13 @@
 package com.nextdv.infrastructure.channel;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChannelPlatformJpaRepository extends JpaRepository<ChannelPlatformEntity, UUID> {
 
   boolean existsByChannelIdAndPlatformIdAndDeletedAtIsNull(UUID channelId, UUID platformId);
+
+  Optional<ChannelPlatformEntity> findByChannelIdAndPlatformIdAndDeletedAtIsNull(
+      UUID channelId, UUID platformId);
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.nextdv.infrastructure.channel;
 
 import com.nextdv.domain.channel.ChannelPlatform;
 import com.nextdv.domain.channel.ChannelPlatformRepository;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -18,6 +19,23 @@ public class ChannelPlatformRepositoryImpl implements ChannelPlatformRepository 
         channelId,
         platformId
     );
+  }
+
+  @Override
+  public Optional<ChannelPlatform> findByChannelIdAndPlatformId(UUID channelId, UUID platformId) {
+    return jpaRepository
+        .findByChannelIdAndPlatformIdAndDeletedAtIsNull(
+            channelId,
+            platformId
+        )
+        .map(
+            entity -> new ChannelPlatform(
+                entity.getId(),
+                entity.getChannelId(),
+                entity.getPlatformId(),
+                entity.getCreatedAt()
+            )
+        );
   }
 
   @Override

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/deliverylog/DeliveryLogEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/deliverylog/DeliveryLogEntity.java
@@ -1,0 +1,49 @@
+package com.nextdv.infrastructure.deliverylog;
+
+import com.nextdv.infrastructure.channel.ChannelPlatformEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "delivery_logs")
+public class DeliveryLogEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(name = "channel_platform_id", nullable = false)
+  private UUID channelPlatformId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "channel_platform_id", insertable = false, updatable = false)
+  private ChannelPlatformEntity channelPlatform;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private DeliveryStatusEntity status;
+
+  @Column(name = "delivered_at", nullable = false)
+  private Instant deliveredAt;
+
+  protected DeliveryLogEntity() {
+  }
+
+  public DeliveryLogEntity(
+      UUID id, UUID channelPlatformId, DeliveryStatusEntity status, Instant deliveredAt) {
+    this.id = id;
+    this.channelPlatformId = channelPlatformId;
+    this.status = status;
+    this.deliveredAt = deliveredAt;
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/deliverylog/DeliveryLogJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/deliverylog/DeliveryLogJpaRepository.java
@@ -1,0 +1,7 @@
+package com.nextdv.infrastructure.deliverylog;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeliveryLogJpaRepository extends JpaRepository<DeliveryLogEntity, UUID> {
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/deliverylog/DeliveryLogRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/deliverylog/DeliveryLogRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.nextdv.infrastructure.deliverylog;
+
+import com.nextdv.domain.deliverylog.DeliveryLog;
+import com.nextdv.domain.deliverylog.DeliveryLogRepository;
+import com.nextdv.domain.deliverylog.DeliveryStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DeliveryLogRepositoryImpl implements DeliveryLogRepository {
+
+  private final DeliveryLogJpaRepository jpaRepository;
+
+  @Override
+  public DeliveryLog save(DeliveryLog log) {
+    DeliveryLogEntity entity = new DeliveryLogEntity(
+        log.getId(),
+        log.getChannelPlatformId(),
+        DeliveryStatusEntity.valueOf(log.getStatus().name()),
+        log.getDeliveredAt()
+    );
+    DeliveryLogEntity saved = jpaRepository.save(entity);
+    return new DeliveryLog(
+        saved.getId(),
+        saved.getChannelPlatformId(),
+        DeliveryStatus.valueOf(saved.getStatus().name()),
+        saved.getDeliveredAt()
+    );
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/deliverylog/DeliveryStatusEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/deliverylog/DeliveryStatusEntity.java
@@ -1,0 +1,5 @@
+package com.nextdv.infrastructure.deliverylog;
+
+public enum DeliveryStatusEntity {
+  PENDING, SUCCESS, FAILED
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
@@ -1,9 +1,13 @@
 package com.nextdv.infrastructure.healthcheck;
 
+import com.nextdv.domain.channel.ChannelPlatformRepository;
 import com.nextdv.domain.channel.ChannelRepository;
 import com.nextdv.domain.channel.DiscordSender;
 import com.nextdv.domain.channel.EmailSender;
 import com.nextdv.domain.channel.SlackSender;
+import com.nextdv.domain.deliverylog.DeliveryLog;
+import com.nextdv.domain.deliverylog.DeliveryLogRepository;
+import com.nextdv.domain.deliverylog.DeliveryStatus;
 import com.nextdv.domain.healthcheck.HealthCheckLog;
 import com.nextdv.domain.healthcheck.HealthCheckLogRepository;
 import com.nextdv.domain.healthcheck.ServiceStatus;
@@ -31,6 +35,8 @@ public class HealthCheckPollService {
   private final EmailSender emailSender;
   private final SlackSender slackSender;
   private final DiscordSender discordSender;
+  private final ChannelPlatformRepository channelPlatformRepository;
+  private final DeliveryLogRepository deliveryLogRepository;
 
   public void pollAll() {
     platformService.findAll().forEach(this::poll);
@@ -95,12 +101,22 @@ public class HealthCheckPollService {
             platform,
             current
         );
+        saveDeliveryLog(
+            channel.getId(),
+            platform.getId(),
+            DeliveryStatus.SUCCESS
+        );
       } catch (Exception e) {
         log.error(
             "이메일 발송 실패 — 채널: {}, 주소: {}",
             channel.getId(),
             address,
             e
+        );
+        saveDeliveryLog(
+            channel.getId(),
+            platform.getId(),
+            DeliveryStatus.FAILED
         );
       }
     });
@@ -112,12 +128,22 @@ public class HealthCheckPollService {
             platform,
             current
         );
+        saveDeliveryLog(
+            channel.getId(),
+            platform.getId(),
+            DeliveryStatus.SUCCESS
+        );
       } catch (Exception e) {
         log.error(
             "Slack 발송 실패 — 채널: {}, URL: {}",
             channel.getId(),
             url,
             e
+        );
+        saveDeliveryLog(
+            channel.getId(),
+            platform.getId(),
+            DeliveryStatus.FAILED
         );
       }
     });
@@ -129,6 +155,11 @@ public class HealthCheckPollService {
             platform,
             current
         );
+        saveDeliveryLog(
+            channel.getId(),
+            platform.getId(),
+            DeliveryStatus.SUCCESS
+        );
       } catch (Exception e) {
         log.error(
             "Discord 발송 실패 — 채널: {}, URL: {}",
@@ -136,8 +167,26 @@ public class HealthCheckPollService {
             url,
             e
         );
+        saveDeliveryLog(
+            channel.getId(),
+            platform.getId(),
+            DeliveryStatus.FAILED
+        );
       }
     });
+  }
+
+  private void saveDeliveryLog(UUID channelId, UUID platformId, DeliveryStatus status) {
+    channelPlatformRepository
+        .findByChannelIdAndPlatformId(
+            channelId,
+            platformId
+        )
+        .ifPresent(
+            cp -> deliveryLogRepository.save(
+                new DeliveryLog(UUID.randomUUID(), cp.getId(), status, Instant.now())
+            )
+        );
   }
 
   ServiceStatus determineStatus(int httpStatus, int responseMs, int degradedThresholdMs) {

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollNotificationTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollNotificationTest.java
@@ -12,6 +12,8 @@ import com.nextdv.infrastructure.channel.ChannelPlatformEntity;
 import com.nextdv.infrastructure.channel.ChannelPlatformJpaRepository;
 import com.nextdv.infrastructure.channel.ChannelRepositoryImpl;
 import com.nextdv.infrastructure.channel.ChannelTypeEntity;
+import com.nextdv.infrastructure.deliverylog.DeliveryLogJpaRepository;
+import com.nextdv.infrastructure.deliverylog.DeliveryStatusEntity;
 import com.nextdv.infrastructure.notification.FakeDiscordSender;
 import com.nextdv.infrastructure.notification.FakeEmailSender;
 import com.nextdv.infrastructure.notification.FakeSlackSender;
@@ -48,6 +50,9 @@ class HealthCheckPollNotificationTest {
 
   @Autowired
   private ChannelRepository channelRepository;
+
+  @Autowired
+  private DeliveryLogJpaRepository deliveryLogJpaRepository;
 
   private FakeEmailSender fakeEmailSender;
   private FakeSlackSender fakeSlackSender;
@@ -266,5 +271,80 @@ class HealthCheckPollNotificationTest {
     assertThat(fakeDiscordSender.getSentUrls()).containsExactly(
         "https://discord.com/api/webhooks/test"
     );
+  }
+
+  @Test
+  void 이메일_발송_성공_시_delivery_log가_SUCCESS로_저장된다() {
+    UUID platformId = UUID.randomUUID();
+    UUID channelId = UUID.randomUUID();
+    UUID channelPlatformId = UUID.randomUUID();
+    Instant now = Instant.now();
+
+    channelJpaRepository.save(
+        new ChannelEntity(
+            channelId, UUID.randomUUID(), ChannelTypeEntity.EMAIL,
+            "이메일", Map.of(
+                "address",
+                "user@example.com"
+            ), now, now, null
+        )
+    );
+    channelPlatformJpaRepository.save(
+        new ChannelPlatformEntity(channelPlatformId, channelId, platformId, now)
+    );
+
+    Platform platform = new Platform(
+        platformId, "GitHub", ServiceCategory.DEVTOOL,
+        "https://github.com", 5000, 2000, null, true
+    );
+
+    service.notifyStatusChange(
+        platform,
+        ServiceStatus.OPERATIONAL,
+        ServiceStatus.MAJOR_OUTAGE
+    );
+
+    assertThat(deliveryLogJpaRepository.findAll()).hasSize(1);
+    assertThat(deliveryLogJpaRepository.findAll().get(0).getChannelPlatformId())
+        .isEqualTo(channelPlatformId);
+    assertThat(deliveryLogJpaRepository.findAll().get(0).getStatus())
+        .isEqualTo(DeliveryStatusEntity.SUCCESS);
+  }
+
+  @Test
+  void 이메일_발송_실패_시_delivery_log가_FAILED로_저장된다() {
+    UUID platformId = UUID.randomUUID();
+    UUID channelId = UUID.randomUUID();
+    UUID channelPlatformId = UUID.randomUUID();
+    Instant now = Instant.now();
+
+    channelJpaRepository.save(
+        new ChannelEntity(
+            channelId, UUID.randomUUID(), ChannelTypeEntity.EMAIL,
+            "이메일", Map.of(
+                "address",
+                "bad-address"
+            ), now, now, null
+        )
+    );
+    channelPlatformJpaRepository.save(
+        new ChannelPlatformEntity(channelPlatformId, channelId, platformId, now)
+    );
+
+    Platform platform = new Platform(
+        platformId, "GitHub", ServiceCategory.DEVTOOL,
+        "https://github.com", 5000, 2000, null, true
+    );
+
+    fakeEmailSender.setShouldFail(true);
+    service.notifyStatusChange(
+        platform,
+        ServiceStatus.OPERATIONAL,
+        ServiceStatus.MAJOR_OUTAGE
+    );
+
+    assertThat(deliveryLogJpaRepository.findAll()).hasSize(1);
+    assertThat(deliveryLogJpaRepository.findAll().get(0).getStatus())
+        .isEqualTo(DeliveryStatusEntity.FAILED);
   }
 }

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollNotificationTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollNotificationTest.java
@@ -10,8 +10,12 @@ import com.nextdv.infrastructure.channel.ChannelEntity;
 import com.nextdv.infrastructure.channel.ChannelJpaRepository;
 import com.nextdv.infrastructure.channel.ChannelPlatformEntity;
 import com.nextdv.infrastructure.channel.ChannelPlatformJpaRepository;
+import com.nextdv.domain.channel.ChannelPlatformRepository;
+import com.nextdv.domain.deliverylog.DeliveryLogRepository;
+import com.nextdv.infrastructure.channel.ChannelPlatformRepositoryImpl;
 import com.nextdv.infrastructure.channel.ChannelRepositoryImpl;
 import com.nextdv.infrastructure.channel.ChannelTypeEntity;
+import com.nextdv.infrastructure.deliverylog.DeliveryLogRepositoryImpl;
 import com.nextdv.infrastructure.deliverylog.DeliveryLogJpaRepository;
 import com.nextdv.infrastructure.deliverylog.DeliveryStatusEntity;
 import com.nextdv.infrastructure.notification.FakeDiscordSender;
@@ -34,7 +38,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
-@Import(ChannelRepositoryImpl.class)
+@Import({ChannelRepositoryImpl.class, ChannelPlatformRepositoryImpl.class,
+    DeliveryLogRepositoryImpl.class})
 @Testcontainers
 class HealthCheckPollNotificationTest {
 
@@ -54,6 +59,12 @@ class HealthCheckPollNotificationTest {
   @Autowired
   private DeliveryLogJpaRepository deliveryLogJpaRepository;
 
+  @Autowired
+  private ChannelPlatformRepository channelPlatformRepository;
+
+  @Autowired
+  private DeliveryLogRepository deliveryLogRepository;
+
   private FakeEmailSender fakeEmailSender;
   private FakeSlackSender fakeSlackSender;
   private FakeDiscordSender fakeDiscordSender;
@@ -65,7 +76,8 @@ class HealthCheckPollNotificationTest {
     fakeSlackSender = new FakeSlackSender();
     fakeDiscordSender = new FakeDiscordSender();
     service = new HealthCheckPollService(
-        null, null, null, channelRepository, fakeEmailSender, fakeSlackSender, fakeDiscordSender
+        null, null, null, channelRepository, fakeEmailSender, fakeSlackSender,
+        fakeDiscordSender, channelPlatformRepository, deliveryLogRepository
     );
   }
 

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollServiceTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollServiceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 class HealthCheckPollServiceTest {
 
   private final HealthCheckPollService service = new HealthCheckPollService(
-      null, null, null, null, null, null, null
+      null, null, null, null, null, null, null, null, null
   );
 
   @Test

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/notification/FakeEmailSender.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/notification/FakeEmailSender.java
@@ -9,13 +9,21 @@ import java.util.List;
 public class FakeEmailSender implements EmailSender {
 
   private final List<String> sentAddresses = new ArrayList<>();
+  private boolean shouldFail = false;
 
   @Override
   public void send(String address, Platform platform, ServiceStatus newStatus) {
+    if (shouldFail) {
+      throw new RuntimeException("SMTP 오류 (테스트용)");
+    }
     sentAddresses.add(address);
   }
 
   public List<String> getSentAddresses() {
     return sentAddresses;
+  }
+
+  public void setShouldFail(boolean shouldFail) {
+    this.shouldFail = shouldFail;
   }
 }


### PR DESCRIPTION
## 변경 내용

MVP SQL 스키마에 정의된 `delivery_logs` 테이블 구현.
알림 발송(이메일/슬랙/디스코드) 성공·실패 이력을 DB에 기록.

### 새 파일 (6개)
- `domain/deliverylog/`: DeliveryStatus, DeliveryLog, DeliveryLogRepository
- `infrastructure/deliverylog/`: DeliveryLogEntity, DeliveryLogJpaRepository, DeliveryLogRepositoryImpl

### 수정 파일 (4개)
- `ChannelPlatformRepository` — `findByChannelIdAndPlatformId()` 추가
- `ChannelPlatformJpaRepository` / `ChannelPlatformRepositoryImpl` — 구현 추가
- `HealthCheckPollService` — 알림 발송 후 `delivery_log` 저장 (성공 → SUCCESS, 실패 → FAILED)

## 테스트

TDD 방식으로 진행.
- `이메일_발송_성공_시_delivery_log가_SUCCESS로_저장된다`
- `이메일_발송_실패_시_delivery_log가_FAILED로_저장된다`

Closes #102