### PR TITLE
feat: 시연용 Test서버 자동 상태 순환 추가

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -22,6 +22,12 @@ spring:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info
+
 app:
   swagger-server-url: ${APP_SWAGGER_SERVER_URL:}
 

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/demo/DemoPlatformHealthChecker.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/demo/DemoPlatformHealthChecker.java
@@ -1,0 +1,37 @@
+package com.nextdv.infrastructure.demo;
+
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.Platform;
+import com.nextdv.infrastructure.healthcheck.HealthCheckResult;
+import com.nextdv.infrastructure.healthcheck.PlatformHealthChecker;
+import java.time.Instant;
+import java.util.Random;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(1)
+class DemoPlatformHealthChecker implements PlatformHealthChecker {
+
+  private static final String DEMO_URL = "demo://test";
+
+  @Override
+  public boolean supports(Platform platform) {
+    return DEMO_URL.equals(platform.getHealthCheckUrl());
+  }
+
+  @Override
+  public HealthCheckResult check(Platform platform) {
+    long windowIndex = Instant.now().getEpochSecond() / 600;
+    return new HealthCheckResult(computeStatus(windowIndex), null, null);
+  }
+
+  ServiceStatus computeStatus(long windowIndex) {
+    int idx = new Random(windowIndex).nextInt(3);
+    return switch (idx) {
+      case 1 -> ServiceStatus.DEGRADED;
+      case 2 -> ServiceStatus.MAJOR_OUTAGE;
+      default -> ServiceStatus.OPERATIONAL;
+    };
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/demo/DemoPlatformSeeder.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/demo/DemoPlatformSeeder.java
@@ -1,0 +1,35 @@
+package com.nextdv.infrastructure.demo;
+
+import com.nextdv.domain.platform.ServiceCategory;
+import com.nextdv.infrastructure.platform.PlatformEntity;
+import com.nextdv.infrastructure.platform.PlatformJpaRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DemoPlatformSeeder implements ApplicationRunner {
+
+  private static final UUID DEMO_ID = UUID.fromString("00000000-0000-0000-0000-000000000099");
+
+  private final PlatformJpaRepository platformJpaRepository;
+
+  @Override
+  public void run(ApplicationArguments args) {
+    platformJpaRepository.save(
+        new PlatformEntity(
+            DEMO_ID,
+            "Test서버",
+            ServiceCategory.OTHER,
+            "demo://test",
+            10000,
+            1000,
+            "https://avatars.githubusercontent.com/u/202518705?s=200&v=4",
+            true
+        )
+    );
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
@@ -10,14 +10,11 @@ import com.nextdv.domain.healthcheck.ServiceStatus;
 import com.nextdv.domain.platform.Platform;
 import com.nextdv.domain.platform.PlatformService;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.ResourceAccessException;
-import org.springframework.web.client.RestClient;
 
 @Slf4j
 @Service
@@ -26,7 +23,7 @@ public class HealthCheckPollService {
 
   private final PlatformService platformService;
   private final HealthCheckLogRepository healthCheckLogRepository;
-  private final RestClient healthCheckRestClient;
+  private final List<PlatformHealthChecker> healthCheckers;
   private final ChannelRepository channelRepository;
   private final EmailSender emailSender;
   private final SlackSender slackSender;
@@ -42,43 +39,26 @@ public class HealthCheckPollService {
         .map(HealthCheckLog::getStatus)
         .orElse(null);
 
-    long startMs = System.currentTimeMillis();
-    ServiceStatus status;
-    Integer responseMs;
-    Integer httpStatusCode;
-    try {
-      ResponseEntity<Void> response = healthCheckRestClient
-          .get()
-          .uri(platform.getHealthCheckUrl())
-          .retrieve()
-          .onStatus(
-              HttpStatusCode::isError,
-              (req, res) -> {
-              }
-          )
-          .toBodilessEntity();
-      responseMs = (int) (System.currentTimeMillis() - startMs);
-      httpStatusCode = response.getStatusCode().value();
-      status = determineStatus(
-          httpStatusCode,
-          responseMs,
-          platform.getDegradedThresholdMs()
-      );
-    } catch (ResourceAccessException e) {
-      responseMs = (int) (System.currentTimeMillis() - startMs);
-      httpStatusCode = null;
-      status = ServiceStatus.MAJOR_OUTAGE;
-    }
+    HealthCheckResult result = healthCheckers.stream()
+        .filter(c -> c.supports(platform))
+        .findFirst()
+        .orElseThrow()
+        .check(platform);
 
     notifyStatusChange(
         platform,
         previousStatus,
-        status
+        result.status()
     );
 
     healthCheckLogRepository.save(
         new HealthCheckLog(
-            UUID.randomUUID(), platform.getId(), status, httpStatusCode, responseMs, Instant.now()
+            UUID.randomUUID(),
+            platform.getId(),
+            result.status(),
+            result.httpStatusCode(),
+            result.responseTimeMs(),
+            Instant.now()
         )
     );
   }
@@ -87,66 +67,68 @@ public class HealthCheckPollService {
     if (previous == null || previous == current) {
       return;
     }
-    channelRepository.findEmailChannelsByPlatformId(platform.getId()).forEach(channel -> {
-      String address = (String) channel.getConfig().get("address");
-      try {
-        emailSender.send(
-            address,
-            platform,
-            current
+    channelRepository
+        .findEmailChannelsByPlatformId(platform.getId())
+        .forEach(
+            channel -> {
+              String address = (String) channel.getConfig().get("address");
+              try {
+                emailSender.send(
+                    address,
+                    platform,
+                    current
+                );
+              } catch (Exception e) {
+                log.error(
+                    "이메일 발송 실패 — 채널: {}, 주소: {}",
+                    channel.getId(),
+                    address,
+                    e
+                );
+              }
+            }
         );
-      } catch (Exception e) {
-        log.error(
-            "이메일 발송 실패 — 채널: {}, 주소: {}",
-            channel.getId(),
-            address,
-            e
+    channelRepository
+        .findSlackChannelsByPlatformId(platform.getId())
+        .forEach(
+            channel -> {
+              String url = (String) channel.getConfig().get("url");
+              try {
+                slackSender.send(
+                    url,
+                    platform,
+                    current
+                );
+              } catch (Exception e) {
+                log.error(
+                    "Slack 발송 실패 — 채널: {}, URL: {}",
+                    channel.getId(),
+                    url,
+                    e
+                );
+              }
+            }
         );
-      }
-    });
-    channelRepository.findSlackChannelsByPlatformId(platform.getId()).forEach(channel -> {
-      String url = (String) channel.getConfig().get("url");
-      try {
-        slackSender.send(
-            url,
-            platform,
-            current
+    channelRepository
+        .findDiscordChannelsByPlatformId(platform.getId())
+        .forEach(
+            channel -> {
+              String url = (String) channel.getConfig().get("url");
+              try {
+                discordSender.send(
+                    url,
+                    platform,
+                    current
+                );
+              } catch (Exception e) {
+                log.error(
+                    "Discord 발송 실패 — 채널: {}, URL: {}",
+                    channel.getId(),
+                    url,
+                    e
+                );
+              }
+            }
         );
-      } catch (Exception e) {
-        log.error(
-            "Slack 발송 실패 — 채널: {}, URL: {}",
-            channel.getId(),
-            url,
-            e
-        );
-      }
-    });
-    channelRepository.findDiscordChannelsByPlatformId(platform.getId()).forEach(channel -> {
-      String url = (String) channel.getConfig().get("url");
-      try {
-        discordSender.send(
-            url,
-            platform,
-            current
-        );
-      } catch (Exception e) {
-        log.error(
-            "Discord 발송 실패 — 채널: {}, URL: {}",
-            channel.getId(),
-            url,
-            e
-        );
-      }
-    });
-  }
-
-  ServiceStatus determineStatus(int httpStatus, int responseMs, int degradedThresholdMs) {
-    if (httpStatus >= 500) {
-      return ServiceStatus.MAJOR_OUTAGE;
-    }
-    if (responseMs >= degradedThresholdMs) {
-      return ServiceStatus.DEGRADED;
-    }
-    return ServiceStatus.OPERATIONAL;
   }
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckResult.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckResult.java
@@ -1,0 +1,7 @@
+package com.nextdv.infrastructure.healthcheck;
+
+import com.nextdv.domain.healthcheck.ServiceStatus;
+
+public record HealthCheckResult(
+    ServiceStatus status, Integer httpStatusCode, Integer responseTimeMs) {
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HttpPlatformHealthChecker.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HttpPlatformHealthChecker.java
@@ -1,0 +1,65 @@
+package com.nextdv.infrastructure.healthcheck;
+
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.Platform;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+@Component
+@Order(Integer.MAX_VALUE)
+@RequiredArgsConstructor
+class HttpPlatformHealthChecker implements PlatformHealthChecker {
+
+  private final RestClient healthCheckRestClient;
+
+  @Override
+  public boolean supports(Platform platform) {
+    return true;
+  }
+
+  @Override
+  public HealthCheckResult check(Platform platform) {
+    long startMs = System.currentTimeMillis();
+    try {
+      ResponseEntity<Void> response = healthCheckRestClient
+          .get()
+          .uri(platform.getHealthCheckUrl())
+          .retrieve()
+          .onStatus(
+              HttpStatusCode::isError,
+              (req, res) -> {
+              }
+          )
+          .toBodilessEntity();
+      int responseMs = (int) (System.currentTimeMillis() - startMs);
+      int httpStatusCode = response.getStatusCode().value();
+      return new HealthCheckResult(
+          determineStatus(
+              httpStatusCode,
+              responseMs,
+              platform.getDegradedThresholdMs()
+          ),
+          httpStatusCode,
+          responseMs
+      );
+    } catch (ResourceAccessException e) {
+      int responseMs = (int) (System.currentTimeMillis() - startMs);
+      return new HealthCheckResult(ServiceStatus.MAJOR_OUTAGE, null, responseMs);
+    }
+  }
+
+  ServiceStatus determineStatus(int httpStatus, int responseMs, int degradedThresholdMs) {
+    if (httpStatus >= 500) {
+      return ServiceStatus.MAJOR_OUTAGE;
+    }
+    if (responseMs >= degradedThresholdMs) {
+      return ServiceStatus.DEGRADED;
+    }
+    return ServiceStatus.OPERATIONAL;
+  }
+}

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/PlatformHealthChecker.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/PlatformHealthChecker.java
@@ -1,0 +1,10 @@
+package com.nextdv.infrastructure.healthcheck;
+
+import com.nextdv.domain.platform.Platform;
+
+public interface PlatformHealthChecker {
+
+  boolean supports(Platform platform);
+
+  HealthCheckResult check(Platform platform);
+}

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/demo/DemoPlatformHealthCheckerTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/demo/DemoPlatformHealthCheckerTest.java
@@ -1,0 +1,49 @@
+package com.nextdv.infrastructure.demo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nextdv.domain.healthcheck.ServiceStatus;
+import com.nextdv.domain.platform.Platform;
+import com.nextdv.domain.platform.ServiceCategory;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class DemoPlatformHealthCheckerTest {
+
+  private final DemoPlatformHealthChecker checker = new DemoPlatformHealthChecker();
+
+  @Test
+  void demo_상태_계산_결과는_유효한_상태중_하나다() {
+    ServiceStatus status = checker.computeStatus(12345L);
+    assertThat(status).isIn(
+        ServiceStatus.OPERATIONAL,
+        ServiceStatus.DEGRADED,
+        ServiceStatus.MAJOR_OUTAGE
+    );
+  }
+
+  @Test
+  void 같은_window_index는_항상_같은_상태를_반환한다() {
+    ServiceStatus first = checker.computeStatus(99L);
+    ServiceStatus second = checker.computeStatus(99L);
+    assertThat(first).isEqualTo(second);
+  }
+
+  @Test
+  void demo_URL_플랫폼은_supports가_true다() {
+    Platform platform = new Platform(
+        UUID.randomUUID(), "Test서버", ServiceCategory.OTHER,
+        "demo://test", 10000, 1000, null, true
+    );
+    assertThat(checker.supports(platform)).isTrue();
+  }
+
+  @Test
+  void 일반_URL_플랫폼은_supports가_false다() {
+    Platform platform = new Platform(
+        UUID.randomUUID(), "GitHub", ServiceCategory.DEVTOOL,
+        "https://github.com", 5000, 2000, null, true
+    );
+    assertThat(checker.supports(platform)).isFalse();
+  }
+}

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/demo/DemoPlatformSeederTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/demo/DemoPlatformSeederTest.java
@@ -1,0 +1,57 @@
+package com.nextdv.infrastructure.demo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nextdv.infrastructure.platform.PlatformEntity;
+import com.nextdv.infrastructure.platform.PlatformJpaRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import(DemoPlatformSeeder.class)
+@Testcontainers
+class DemoPlatformSeederTest {
+
+  private static final UUID DEMO_ID = UUID.fromString("00000000-0000-0000-0000-000000000099");
+
+  @Container
+  @ServiceConnection
+  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+  @Autowired
+  private PlatformJpaRepository platformJpaRepository;
+
+  @Autowired
+  private DemoPlatformSeeder seeder;
+
+  @Test
+  void 서버_시작_시_Test서버가_DB에_저장된다() throws Exception {
+    seeder.run(null);
+
+    Optional<PlatformEntity> result = platformJpaRepository.findById(DEMO_ID);
+    assertThat(result).isPresent();
+    assertThat(result.get().getName()).isEqualTo("Test서버");
+  }
+
+  @Test
+  void 중복_실행해도_Test서버는_하나만_존재한다() throws Exception {
+    seeder.run(null);
+    seeder.run(null);
+
+    long count = platformJpaRepository.findAll().stream()
+        .filter(p -> p.getId().equals(DEMO_ID))
+        .count();
+    assertThat(count).isEqualTo(1);
+  }
+}

--- a/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HttpPlatformHealthCheckerTest.java
+++ b/infrastructure/src/test/java/com/nextdv/infrastructure/healthcheck/HttpPlatformHealthCheckerTest.java
@@ -5,15 +5,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.nextdv.domain.healthcheck.ServiceStatus;
 import org.junit.jupiter.api.Test;
 
-class HealthCheckPollServiceTest {
+class HttpPlatformHealthCheckerTest {
 
-  private final HealthCheckPollService service = new HealthCheckPollService(
-      null, null, null, null, null, null, null
-  );
+  private final HttpPlatformHealthChecker checker = new HttpPlatformHealthChecker(null);
 
   @Test
   void 응답이_2xx이고_임계값_미만이면_OPERATIONAL() {
-    ServiceStatus status = service.determineStatus(
+    ServiceStatus status = checker.determineStatus(
         200,
         500,
         1000
@@ -23,7 +21,7 @@ class HealthCheckPollServiceTest {
 
   @Test
   void 응답이_2xx이고_임계값_이상이면_DEGRADED() {
-    ServiceStatus status = service.determineStatus(
+    ServiceStatus status = checker.determineStatus(
         200,
         1000,
         1000
@@ -33,7 +31,7 @@ class HealthCheckPollServiceTest {
 
   @Test
   void 응답이_4xx이면_OPERATIONAL() {
-    ServiceStatus status = service.determineStatus(
+    ServiceStatus status = checker.determineStatus(
         404,
         100,
         1000
@@ -43,7 +41,7 @@ class HealthCheckPollServiceTest {
 
   @Test
   void 응답이_5xx이면_MAJOR_OUTAGE() {
-    ServiceStatus status = service.determineStatus(
+    ServiceStatus status = checker.determineStatus(
         500,
         100,
         1000


### PR DESCRIPTION
Closes #106
Closes #108

## 변경 내용

시연 영상 촬영 시 실제 장애 없이도 알림 흐름을 보여주기 위해 "Test서버" 가짜 플랫폼을 추가하고, 기존 폴링 서비스에 Strategy Pattern을 도입해 demo 로직을 완전히 분리했습니다.

### 기능: Test서버 자동 상태 순환
- `DemoPlatformSeeder` — 서버 시작 시 Test서버를 DB에 upsert (고정 UUID)
- 10분 window 기반 시드 랜덤으로 OPERATIONAL / DEGRADED / MAJOR_OUTAGE 순환
- 같은 window 내 서버 재시작해도 동일 상태 유지
- 상태 변화 시 기존 이메일 / Slack / Discord 알림 그대로 동작

### 구조 개선: Strategy Pattern
기존 `HealthCheckPollService`에 섞여 있던 demo 분기를 제거하고 체커 인터페이스로 분리

```
PlatformHealthChecker (interface)
├── HttpPlatformHealthChecker  — HTTP 폴링 + 상태 판단 로직
└── DemoPlatformHealthChecker  — demo 상태 순환 (demo/ 패키지)

HealthCheckPollService  — 조율만 담당, demo 코드 0줄
```

### 파일 변경 목록
| 구분 | 파일 |
|---|---|
| 신규 | `PlatformHealthChecker.java` (인터페이스) |
| 신규 | `HealthCheckResult.java` (record) |
| 신규 | `HttpPlatformHealthChecker.java` |
| 신규 | `DemoPlatformSeeder.java` |
| 신규 | `DemoPlatformHealthChecker.java` |
| 수정 | `HealthCheckPollService.java` |
| 삭제 | `HealthCheckPollServiceTest.java` → 아래 두 파일로 대체 |
| 신규 | `HttpPlatformHealthCheckerTest.java` |
| 신규 | `DemoPlatformSeederTest.java` |
| 신규 | `DemoPlatformHealthCheckerTest.java` |

### DB 변경 없음