### PR TITLE
refactor: 주석 형식 통일 및 Log4j2 교체

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -2,12 +2,19 @@ plugins {
     id 'org.springframework.boot'
 }
 
+configurations {
+    all {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
+}
+
 dependencies {
     implementation project(':domain')
     runtimeOnly    project(':infrastructure')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-log4j2'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.1.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/api/src/main/java/com/nextdv/api/HeartbeatApplication.java
+++ b/api/src/main/java/com/nextdv/api/HeartbeatApplication.java
@@ -3,6 +3,11 @@ package com.nextdv.api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * class: HeartbeatApplication 작성자: JBumLee
+ *
+ * Spring Boot 애플리케이션 진입점
+ */
 @SpringBootApplication(scanBasePackages = "com.nextdv")
 public class HeartbeatApplication {
 

--- a/api/src/main/java/com/nextdv/api/account/AccountController.java
+++ b/api/src/main/java/com/nextdv/api/account/AccountController.java
@@ -15,6 +15,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * class: AccountController 작성자: JBumLee
+ *
+ * 계정 관련 REST API 엔드포인트를 제공하는 컨트롤러
+ */
 @RestController
 @RequestMapping("/accounts")
 @RequiredArgsConstructor
@@ -22,6 +27,13 @@ public class AccountController {
 
   private final AccountService accountService;
 
+  /**
+   * 메소드이름: list
+   *
+   * @return: 전체 계정 목록 응답
+   *
+   *          등록된 모든 계정을 조회한다
+   */
   @GetMapping
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<List<AccountResponse>>> list() {
@@ -30,6 +42,14 @@ public class AccountController {
     return ResponseEntity.ok(CommonResponse.ok(data));
   }
 
+  /**
+   * 메소드이름: create
+   *
+   * @parameter: request - 계정 생성 요청 (이메일 포함)
+   * @return: 생성된 계정 응답
+   *
+   *          이메일로 신규 계정을 생성한다
+   */
   @PostMapping
   @ApiResponse(responseCode = "400", description = "이메일 필드 누락 또는 이메일 형식 오류")
   @ApiResponse(responseCode = "409", description = "이미 사용 중인 이메일")

--- a/api/src/main/java/com/nextdv/api/account/AccountMapper.java
+++ b/api/src/main/java/com/nextdv/api/account/AccountMapper.java
@@ -3,15 +3,36 @@ package com.nextdv.api.account;
 import com.nextdv.domain.account.Account;
 import java.util.List;
 
+/**
+ * class: AccountMapper 작성자: JBumLee
+ *
+ * Account 도메인 객체를 AccountResponse DTO로 변환하는 매퍼
+ */
 public class AccountMapper {
 
   private AccountMapper() {
   }
 
+  /**
+   * 메소드이름: toResponse
+   *
+   * @parameter: account - 변환할 계정 도메인 객체
+   * @return: AccountResponse DTO
+   *
+   *          Account 도메인 객체를 응답 DTO로 변환한다
+   */
   public static AccountResponse toResponse(Account account) {
     return new AccountResponse(account.getId(), account.getEmail());
   }
 
+  /**
+   * 메소드이름: toResponseList
+   *
+   * @parameter: accounts - 변환할 계정 도메인 객체 목록
+   * @return: AccountResponse DTO 목록
+   *
+   *          Account 도메인 객체 목록을 응답 DTO 목록으로 변환한다
+   */
   public static List<AccountResponse> toResponseList(
       List<Account> accounts) {
     return accounts.stream().map(AccountMapper::toResponse).toList();

--- a/api/src/main/java/com/nextdv/api/account/AccountRequest.java
+++ b/api/src/main/java/com/nextdv/api/account/AccountRequest.java
@@ -3,6 +3,11 @@ package com.nextdv.api.account;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
+/**
+ * class: AccountRequest 작성자: JBumLee
+ *
+ * 계정 생성 요청 DTO
+ */
 public class AccountRequest {
 
   @NotBlank(message = "이메일은 필수입니다.")

--- a/api/src/main/java/com/nextdv/api/account/AccountResponse.java
+++ b/api/src/main/java/com/nextdv/api/account/AccountResponse.java
@@ -2,6 +2,11 @@ package com.nextdv.api.account;
 
 import java.util.UUID;
 
+/**
+ * class: AccountResponse 작성자: JBumLee
+ *
+ * 계정 조회 응답 DTO
+ */
 public class AccountResponse {
 
   private final UUID id;

--- a/api/src/main/java/com/nextdv/api/channel/ChannelController.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelController.java
@@ -18,6 +18,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * class: ChannelController 작성자: JBumLee
+ *
+ * 알림 채널 관련 REST API 엔드포인트를 제공하는 컨트롤러
+ */
 @RestController
 @RequestMapping("/channels")
 public class ChannelController {
@@ -28,6 +33,14 @@ public class ChannelController {
     this.channelService = channelService;
   }
 
+  /**
+   * 메소드이름: create
+   *
+   * @parameter: request - 채널 생성 요청 (userId, type, name, config 포함)
+   * @return: 생성된 채널 응답
+   *
+   *          새로운 알림 채널을 생성한다
+   */
   @PostMapping
   @ApiResponse(responseCode = "400", description = "userId, type, name, config 필수 필드 누락 또는 형식 오류")
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
@@ -43,6 +56,14 @@ public class ChannelController {
         .body(CommonResponse.ok(ChannelMapper.toResponse(channel)));
   }
 
+  /**
+   * 메소드이름: list
+   *
+   * @parameter: userId - 채널 소유자 UUID
+   * @return: 해당 사용자의 채널 목록 응답
+   *
+   *          특정 사용자의 알림 채널 목록을 조회한다
+   */
   @GetMapping
   @ApiResponse(responseCode = "400", description = "userId 파라미터 누락 또는 UUID 형식이 아님")
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
@@ -51,6 +72,14 @@ public class ChannelController {
     return ResponseEntity.ok(CommonResponse.ok(ChannelMapper.toResponseList(channels)));
   }
 
+  /**
+   * 메소드이름: delete
+   *
+   * @parameter: id - 삭제할 채널 UUID
+   * @return: 성공 응답
+   *
+   *          알림 채널을 소프트 삭제 처리한다
+   */
   @DeleteMapping("/{id}")
   @ApiResponse(responseCode = "400", description = "id가 UUID 형식이 아님")
   @ApiResponse(responseCode = "404", description = "해당 ID에 해당하는 채널이 존재하지 않음")

--- a/api/src/main/java/com/nextdv/api/channel/ChannelMapper.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelMapper.java
@@ -3,8 +3,21 @@ package com.nextdv.api.channel;
 import com.nextdv.domain.channel.Channel;
 import java.util.List;
 
+/**
+ * class: ChannelMapper 작성자: JBumLee
+ *
+ * Channel 도메인 객체를 ChannelResponse DTO로 변환하는 매퍼
+ */
 public class ChannelMapper {
 
+  /**
+   * 메소드이름: toResponse
+   *
+   * @parameter: channel - 변환할 채널 도메인 객체
+   * @return: ChannelResponse DTO
+   *
+   *          Channel 도메인 객체를 응답 DTO로 변환한다
+   */
   public static ChannelResponse toResponse(Channel channel) {
     return new ChannelResponse(
         channel.getId(),
@@ -16,6 +29,14 @@ public class ChannelMapper {
     );
   }
 
+  /**
+   * 메소드이름: toResponseList
+   *
+   * @parameter: channels - 변환할 채널 도메인 객체 목록
+   * @return: ChannelResponse DTO 목록
+   *
+   *          Channel 도메인 객체 목록을 응답 DTO 목록으로 변환한다
+   */
   public static List<ChannelResponse> toResponseList(List<Channel> channels) {
     return channels.stream().map(ChannelMapper::toResponse).toList();
   }

--- a/api/src/main/java/com/nextdv/api/channel/ChannelPlatformController.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelPlatformController.java
@@ -12,6 +12,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * class: ChannelPlatformController 작성자: JBumLee
+ *
+ * 채널-플랫폼 구독 관련 REST API 엔드포인트를 제공하는 컨트롤러
+ */
 @RestController
 @RequestMapping("/channel-platforms")
 public class ChannelPlatformController {
@@ -22,6 +27,14 @@ public class ChannelPlatformController {
     this.channelPlatformService = channelPlatformService;
   }
 
+  /**
+   * 메소드이름: subscribe
+   *
+   * @parameter: request - 구독 요청 (channelId, platformId 포함)
+   * @return: 생성된 구독 정보 응답
+   *
+   *          채널과 플랫폼을 연결하는 구독을 생성한다
+   */
   @PostMapping
   @ApiResponse(responseCode = "400", description = "channelId 또는 platformId 누락 또는 UUID 형식이 아님")
   @ApiResponse(responseCode = "404", description = "해당 channelId 또는 platformId에 해당하는 리소스가 존재하지 않음")

--- a/api/src/main/java/com/nextdv/api/channel/ChannelPlatformRequest.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelPlatformRequest.java
@@ -4,6 +4,11 @@ import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * class: ChannelPlatformRequest 작성자: JBumLee
+ *
+ * 채널-플랫폼 구독 생성 요청 DTO
+ */
 @Getter
 public class ChannelPlatformRequest {
 

--- a/api/src/main/java/com/nextdv/api/channel/ChannelPlatformResponse.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelPlatformResponse.java
@@ -6,6 +6,11 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * class: ChannelPlatformResponse 작성자: JBumLee
+ *
+ * 채널-플랫폼 구독 정보 응답 DTO
+ */
 @Getter
 @AllArgsConstructor
 public class ChannelPlatformResponse {
@@ -15,6 +20,14 @@ public class ChannelPlatformResponse {
   private UUID platformId;
   private Instant createdAt;
 
+  /**
+   * 메소드이름: from
+   *
+   * @parameter: channelPlatform - 변환할 채널-플랫폼 도메인 객체
+   * @return: ChannelPlatformResponse DTO
+   *
+   *          ChannelPlatform 도메인 객체를 응답 DTO로 변환한다
+   */
   public static ChannelPlatformResponse from(ChannelPlatform channelPlatform) {
     return new ChannelPlatformResponse(
         channelPlatform.getId(),

--- a/api/src/main/java/com/nextdv/api/channel/ChannelRequest.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelRequest.java
@@ -7,6 +7,11 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * class: ChannelRequest 작성자: JBumLee
+ *
+ * 채널 생성 요청 DTO
+ */
 @Getter
 public class ChannelRequest {
 

--- a/api/src/main/java/com/nextdv/api/channel/ChannelResponse.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelResponse.java
@@ -5,6 +5,11 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * class: ChannelResponse 작성자: JBumLee
+ *
+ * 채널 조회 응답 DTO
+ */
 public class ChannelResponse {
 
   private final UUID id;

--- a/api/src/main/java/com/nextdv/api/common/CommonResponse.java
+++ b/api/src/main/java/com/nextdv/api/common/CommonResponse.java
@@ -1,5 +1,10 @@
 package com.nextdv.api.common;
 
+/**
+ * class: CommonResponse 작성자: JBumLee
+ *
+ * API 공통 응답 래퍼 클래스
+ */
 public class CommonResponse<T> {
 
   private final boolean success;
@@ -12,14 +17,38 @@ public class CommonResponse<T> {
     this.message = message;
   }
 
+  /**
+   * 메소드이름: ok
+   *
+   * @parameter: data - 응답 데이터
+   * @return: 성공 응답 객체
+   *
+   *          데이터를 포함한 성공 응답을 생성한다
+   */
   public static <T> CommonResponse<T> ok(T data) {
     return new CommonResponse<>(true, data, null);
   }
 
+  /**
+   * 메소드이름: ok
+   *
+   * @parameter: data - 응답 데이터, message - 응답 메시지
+   * @return: 성공 응답 객체
+   *
+   *          데이터와 메시지를 포함한 성공 응답을 생성한다
+   */
   public static <T> CommonResponse<T> ok(T data, String message) {
     return new CommonResponse<>(true, data, message);
   }
 
+  /**
+   * 메소드이름: fail
+   *
+   * @parameter: message - 실패 메시지
+   * @return: 실패 응답 객체
+   *
+   *          실패 메시지를 포함한 실패 응답을 생성한다
+   */
   public static <T> CommonResponse<T> fail(String message) {
     return new CommonResponse<>(false, null, message);
   }

--- a/api/src/main/java/com/nextdv/api/common/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/nextdv/api/common/GlobalExceptionHandler.java
@@ -11,6 +11,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+/**
+ * class: GlobalExceptionHandler 작성자: JBumLee
+ *
+ * 전역 예외를 처리하여 공통 응답 형식으로 변환하는 핸들러
+ */
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {

--- a/api/src/main/java/com/nextdv/api/common/SwaggerConfig.java
+++ b/api/src/main/java/com/nextdv/api/common/SwaggerConfig.java
@@ -7,6 +7,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * class: SwaggerConfig 작성자: JBumLee
+ *
+ * Swagger UI 서버 URL 설정 (Traefik/Cloudflare 환경에서 https 강제)
+ */
 @Configuration
 public class SwaggerConfig {
 

--- a/api/src/main/java/com/nextdv/api/health/HealthController.java
+++ b/api/src/main/java/com/nextdv/api/health/HealthController.java
@@ -10,6 +10,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * class: HealthController 작성자: JBumLee
+ *
+ * 서버 헬스체크 엔드포인트를 제공하는 컨트롤러
+ */
 @RestController
 @RequestMapping("/health")
 @RequiredArgsConstructor
@@ -17,6 +22,13 @@ public class HealthController {
 
   private final HealthService healthService;
 
+  /**
+   * 메소드이름: health
+   *
+   * @return: 서버 상태 응답
+   *
+   *          서버가 정상 동작 중인지 확인하는 헬스체크를 수행한다
+   */
   @GetMapping
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<HealthResponse>> health() {

--- a/api/src/main/java/com/nextdv/api/health/HealthMapper.java
+++ b/api/src/main/java/com/nextdv/api/health/HealthMapper.java
@@ -2,11 +2,24 @@ package com.nextdv.api.health;
 
 import com.nextdv.domain.health.HealthResult;
 
+/**
+ * class: HealthMapper 작성자: JBumLee
+ *
+ * HealthResult 도메인 객체를 HealthResponse DTO로 변환하는 매퍼
+ */
 public class HealthMapper {
 
   private HealthMapper() {
   }
 
+  /**
+   * 메소드이름: toResponse
+   *
+   * @parameter: result - 변환할 헬스체크 결과 도메인 객체
+   * @return: HealthResponse DTO
+   *
+   *          HealthResult 도메인 객체를 응답 DTO로 변환한다
+   */
   public static HealthResponse toResponse(HealthResult result) {
     return new HealthResponse(result.getStatus());
   }

--- a/api/src/main/java/com/nextdv/api/health/HealthResponse.java
+++ b/api/src/main/java/com/nextdv/api/health/HealthResponse.java
@@ -1,5 +1,10 @@
 package com.nextdv.api.health;
 
+/**
+ * class: HealthResponse 작성자: JBumLee
+ *
+ * 서버 헬스체크 응답 DTO
+ */
 public class HealthResponse {
 
   private final String status;

--- a/api/src/main/java/com/nextdv/api/healthcheck/HealthCheckLogMapper.java
+++ b/api/src/main/java/com/nextdv/api/healthcheck/HealthCheckLogMapper.java
@@ -3,8 +3,21 @@ package com.nextdv.api.healthcheck;
 import com.nextdv.domain.healthcheck.HealthCheckLog;
 import java.util.List;
 
+/**
+ * class: HealthCheckLogMapper 작성자: JBumLee
+ *
+ * HealthCheckLog 도메인 객체를 HealthCheckLogResponse DTO로 변환하는 매퍼
+ */
 public class HealthCheckLogMapper {
 
+  /**
+   * 메소드이름: toResponse
+   *
+   * @parameter: log - 변환할 헬스체크 로그 도메인 객체
+   * @return: HealthCheckLogResponse DTO
+   *
+   *          HealthCheckLog 도메인 객체를 응답 DTO로 변환한다
+   */
   public static HealthCheckLogResponse toResponse(HealthCheckLog log) {
     return new HealthCheckLogResponse(
         log.getId(),
@@ -15,6 +28,14 @@ public class HealthCheckLogMapper {
     );
   }
 
+  /**
+   * 메소드이름: toResponseList
+   *
+   * @parameter: logs - 변환할 헬스체크 로그 도메인 객체 목록
+   * @return: HealthCheckLogResponse DTO 목록
+   *
+   *          HealthCheckLog 도메인 객체 목록을 응답 DTO 목록으로 변환한다
+   */
   public static List<HealthCheckLogResponse> toResponseList(List<HealthCheckLog> logs) {
     return logs.stream().map(HealthCheckLogMapper::toResponse).toList();
   }

--- a/api/src/main/java/com/nextdv/api/healthcheck/HealthCheckLogResponse.java
+++ b/api/src/main/java/com/nextdv/api/healthcheck/HealthCheckLogResponse.java
@@ -6,6 +6,11 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * class: HealthCheckLogResponse 작성자: JBumLee
+ *
+ * 헬스체크 로그 응답 DTO
+ */
 @Getter
 @AllArgsConstructor
 public class HealthCheckLogResponse {

--- a/api/src/main/java/com/nextdv/api/healthcheck/PlatformStatusController.java
+++ b/api/src/main/java/com/nextdv/api/healthcheck/PlatformStatusController.java
@@ -14,6 +14,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * class: PlatformStatusController 작성자: JBumLee
+ *
+ * 플랫폼 헬스체크 상태 조회 REST API 엔드포인트를 제공하는 컨트롤러
+ */
 @RestController
 @RequestMapping("/platforms")
 @RequiredArgsConstructor
@@ -22,6 +27,14 @@ public class PlatformStatusController {
   private final HealthCheckLogService healthCheckLogService;
   private final PlatformService platformService;
 
+  /**
+   * 메소드이름: getStatus
+   *
+   * @parameter: id - 조회할 플랫폼 UUID
+   * @return: 가장 최근 헬스체크 상태 응답
+   *
+   *          특정 플랫폼의 최신 헬스체크 상태를 조회한다
+   */
   @GetMapping("/{id}/status")
   @ApiResponse(responseCode = "400", description = "id가 UUID 형식이 아님")
   @ApiResponse(responseCode = "404", description = "해당 ID에 해당하는 플랫폼이 존재하지 않음")
@@ -36,6 +49,14 @@ public class PlatformStatusController {
         .orElse(ResponseEntity.ok(CommonResponse.ok(null)));
   }
 
+  /**
+   * 메소드이름: getLogs
+   *
+   * @parameter: id - 조회할 플랫폼 UUID
+   * @return: 전체 헬스체크 로그 응답 목록
+   *
+   *          특정 플랫폼의 모든 헬스체크 로그를 조회한다
+   */
   @GetMapping("/{id}/logs")
   @ApiResponse(responseCode = "400", description = "id가 UUID 형식이 아님")
   @ApiResponse(responseCode = "404", description = "해당 ID에 해당하는 플랫폼이 존재하지 않음")

--- a/api/src/main/java/com/nextdv/api/platform/PlatformController.java
+++ b/api/src/main/java/com/nextdv/api/platform/PlatformController.java
@@ -14,6 +14,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * class: PlatformController 작성자: JBumLee
+ *
+ * 플랫폼 조회 REST API 엔드포인트를 제공하는 컨트롤러
+ */
 @RestController
 @RequestMapping("/platforms")
 @RequiredArgsConstructor
@@ -21,6 +26,13 @@ public class PlatformController {
 
   private final PlatformService platformService;
 
+  /**
+   * 메소드이름: list
+   *
+   * @return: 활성화된 플랫폼 목록 응답
+   *
+   *          활성화 상태인 모든 플랫폼을 조회한다
+   */
   @GetMapping
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<List<PlatformResponse>>> list() {
@@ -28,6 +40,14 @@ public class PlatformController {
     return ResponseEntity.ok(CommonResponse.ok(PlatformMapper.toResponseList(platforms)));
   }
 
+  /**
+   * 메소드이름: findById
+   *
+   * @parameter: id - 조회할 플랫폼 UUID
+   * @return: 플랫폼 응답
+   *
+   *          ID로 특정 플랫폼을 조회한다
+   */
   @GetMapping("/{id}")
   @ApiResponse(responseCode = "400", description = "id가 UUID 형식이 아님")
   @ApiResponse(responseCode = "404", description = "해당 ID에 해당하는 플랫폼이 존재하지 않음")

--- a/api/src/main/java/com/nextdv/api/platform/PlatformMapper.java
+++ b/api/src/main/java/com/nextdv/api/platform/PlatformMapper.java
@@ -3,11 +3,24 @@ package com.nextdv.api.platform;
 import com.nextdv.domain.platform.Platform;
 import java.util.List;
 
+/**
+ * class: PlatformMapper 작성자: JBumLee
+ *
+ * Platform 도메인 객체를 PlatformResponse DTO로 변환하는 매퍼
+ */
 public class PlatformMapper {
 
   private PlatformMapper() {
   }
 
+  /**
+   * 메소드이름: toResponse
+   *
+   * @parameter: platform - 변환할 플랫폼 도메인 객체
+   * @return: PlatformResponse DTO
+   *
+   *          Platform 도메인 객체를 응답 DTO로 변환한다
+   */
   public static PlatformResponse toResponse(Platform platform) {
     return new PlatformResponse(
         platform.getId(),
@@ -21,6 +34,14 @@ public class PlatformMapper {
     );
   }
 
+  /**
+   * 메소드이름: toResponseList
+   *
+   * @parameter: platforms - 변환할 플랫폼 도메인 객체 목록
+   * @return: PlatformResponse DTO 목록
+   *
+   *          Platform 도메인 객체 목록을 응답 DTO 목록으로 변환한다
+   */
   public static List<PlatformResponse> toResponseList(List<Platform> platforms) {
     return platforms.stream()
         .map(PlatformMapper::toResponse)

--- a/api/src/main/java/com/nextdv/api/platform/PlatformResponse.java
+++ b/api/src/main/java/com/nextdv/api/platform/PlatformResponse.java
@@ -4,6 +4,11 @@ import com.nextdv.domain.platform.ServiceCategory;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * class: PlatformResponse 작성자: JBumLee
+ *
+ * 플랫폼 조회 응답 DTO
+ */
 @Getter
 public class PlatformResponse {
 

--- a/api/src/main/resources/log4j2.xml
+++ b/api/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/domain/src/main/java/com/nextdv/domain/account/Account.java
+++ b/domain/src/main/java/com/nextdv/domain/account/Account.java
@@ -2,6 +2,11 @@ package com.nextdv.domain.account;
 
 import java.util.UUID;
 
+/**
+ * class: Account 작성자: JBumLee
+ *
+ * 사용자 계정 도메인 객체
+ */
 public class Account {
 
   private final UUID id;

--- a/domain/src/main/java/com/nextdv/domain/account/AccountRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/account/AccountRepository.java
@@ -2,11 +2,39 @@ package com.nextdv.domain.account;
 
 import java.util.List;
 
+/**
+ * class: AccountRepository 작성자: JBumLee
+ *
+ * 계정 도메인 저장소 인터페이스
+ */
 public interface AccountRepository {
 
+  /**
+   * 메소드이름: findAll
+   *
+   * @return: 전체 계정 목록
+   *
+   *          모든 계정을 조회한다
+   */
   List<Account> findAll();
 
+  /**
+   * 메소드이름: save
+   *
+   * @parameter: account - 저장할 계정 객체
+   * @return: 저장된 계정 객체
+   *
+   *          계정을 저장한다
+   */
   Account save(Account account);
 
+  /**
+   * 메소드이름: existsByEmail
+   *
+   * @parameter: email - 중복 확인할 이메일 주소
+   * @return: 이메일 존재 여부
+   *
+   *          해당 이메일로 가입된 계정이 존재하는지 확인한다
+   */
   boolean existsByEmail(String email);
 }

--- a/domain/src/main/java/com/nextdv/domain/account/AccountService.java
+++ b/domain/src/main/java/com/nextdv/domain/account/AccountService.java
@@ -5,16 +5,36 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * class: AccountService 작성자: JBumLee
+ *
+ * 계정 생성 및 조회 비즈니스 로직을 담당하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class AccountService {
 
   private final AccountRepository accountRepository;
 
+  /**
+   * 메소드이름: findAll
+   *
+   * @return: 전체 계정 목록
+   *
+   *          모든 계정을 조회한다
+   */
   public List<Account> findAll() {
     return accountRepository.findAll();
   }
 
+  /**
+   * 메소드이름: create
+   *
+   * @parameter: email - 생성할 계정의 이메일 주소
+   * @return: 생성된 계정 객체
+   *
+   *          이메일 유효성 검증 후 신규 계정을 생성한다
+   */
   public Account create(String email) {
     if (email == null || email.isBlank()) {
       throw new IllegalArgumentException("이메일은 필수입니다.");

--- a/domain/src/main/java/com/nextdv/domain/channel/Channel.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/Channel.java
@@ -5,6 +5,11 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * class: Channel 작성자: JBumLee
+ *
+ * 알림 채널 도메인 객체
+ */
 @Getter
 public class Channel {
 

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatform.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatform.java
@@ -5,6 +5,11 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * class: ChannelPlatform 작성자: JBumLee
+ *
+ * 채널-플랫폼 구독 관계 도메인 객체
+ */
 @Getter
 @AllArgsConstructor
 public class ChannelPlatform {

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformRepository.java
@@ -2,9 +2,30 @@ package com.nextdv.domain.channel;
 
 import java.util.UUID;
 
+/**
+ * class: ChannelPlatformRepository 작성자: JBumLee
+ *
+ * 채널-플랫폼 구독 도메인 저장소 인터페이스
+ */
 public interface ChannelPlatformRepository {
 
+  /**
+   * 메소드이름: save
+   *
+   * @parameter: channelPlatform - 저장할 채널-플랫폼 구독 객체
+   * @return: 저장된 채널-플랫폼 구독 객체
+   *
+   *          채널-플랫폼 구독 정보를 저장한다
+   */
   ChannelPlatform save(ChannelPlatform channelPlatform);
 
+  /**
+   * 메소드이름: existsByChannelIdAndPlatformId
+   *
+   * @parameter: channelId - 채널 UUID, platformId - 플랫폼 UUID
+   * @return: 구독 존재 여부
+   *
+   *          해당 채널과 플랫폼 조합의 활성 구독이 존재하는지 확인한다
+   */
   boolean existsByChannelIdAndPlatformId(UUID channelId, UUID platformId);
 }

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformService.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformService.java
@@ -7,6 +7,11 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * class: ChannelPlatformService 작성자: JBumLee
+ *
+ * 채널-플랫폼 구독 비즈니스 로직을 담당하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class ChannelPlatformService {
@@ -15,6 +20,14 @@ public class ChannelPlatformService {
   private final ChannelRepository channelRepository;
   private final PlatformRepository platformRepository;
 
+  /**
+   * 메소드이름: subscribe
+   *
+   * @parameter: channelId - 구독할 채널 UUID, platformId - 구독할 플랫폼 UUID
+   * @return: 생성된 채널-플랫폼 구독 객체
+   *
+   *          채널과 플랫폼이 존재하고 중복 구독이 아닌 경우 구독을 생성한다
+   */
   public ChannelPlatform subscribe(UUID channelId, UUID platformId) {
     channelRepository
         .findById(channelId)

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelRepository.java
@@ -4,17 +4,70 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * class: ChannelRepository 작성자: JBumLee
+ *
+ * 알림 채널 도메인 저장소 인터페이스
+ */
 public interface ChannelRepository {
 
+  /**
+   * 메소드이름: save
+   *
+   * @parameter: channel - 저장할 채널 객체
+   * @return: 저장된 채널 객체
+   *
+   *          채널을 저장한다
+   */
   Channel save(Channel channel);
 
+  /**
+   * 메소드이름: findAllByUserId
+   *
+   * @parameter: userId - 조회할 사용자 UUID
+   * @return: 해당 사용자의 채널 목록
+   *
+   *          특정 사용자의 삭제되지 않은 채널 목록을 조회한다
+   */
   List<Channel> findAllByUserId(UUID userId);
 
+  /**
+   * 메소드이름: findById
+   *
+   * @parameter: id - 조회할 채널 UUID
+   * @return: 채널 객체 (없으면 empty)
+   *
+   *          ID로 채널을 조회한다
+   */
   Optional<Channel> findById(UUID id);
 
+  /**
+   * 메소드이름: findEmailChannelsByPlatformId
+   *
+   * @parameter: platformId - 조회할 플랫폼 UUID
+   * @return: 해당 플랫폼을 구독 중인 이메일 채널 목록
+   *
+   *          특정 플랫폼을 구독 중인 이메일 채널을 조회한다
+   */
   List<Channel> findEmailChannelsByPlatformId(UUID platformId);
 
+  /**
+   * 메소드이름: findSlackChannelsByPlatformId
+   *
+   * @parameter: platformId - 조회할 플랫폼 UUID
+   * @return: 해당 플랫폼을 구독 중인 Slack 채널 목록
+   *
+   *          특정 플랫폼을 구독 중인 Slack 채널을 조회한다
+   */
   List<Channel> findSlackChannelsByPlatformId(UUID platformId);
 
+  /**
+   * 메소드이름: findDiscordChannelsByPlatformId
+   *
+   * @parameter: platformId - 조회할 플랫폼 UUID
+   * @return: 해당 플랫폼을 구독 중인 Discord 채널 목록
+   *
+   *          특정 플랫폼을 구독 중인 Discord 채널을 조회한다
+   */
   List<Channel> findDiscordChannelsByPlatformId(UUID platformId);
 }

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelService.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelService.java
@@ -8,12 +8,25 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * class: ChannelService 작성자: JBumLee
+ *
+ * 알림 채널 생성, 조회, 삭제 비즈니스 로직을 담당하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class ChannelService {
 
   private final ChannelRepository channelRepository;
 
+  /**
+   * 메소드이름: create
+   *
+   * @parameter: userId - 채널 소유자 UUID, type - 채널 타입, name - 채널 이름, config - 채널 설정값
+   * @return: 생성된 채널 객체
+   *
+   *          채널 타입별 config 유효성 검증 후 채널을 생성한다
+   */
   public Channel create(
       UUID userId, ChannelType type, String name, Map<String, Object> config) {
     validateConfig(
@@ -50,10 +63,25 @@ public class ChannelService {
     }
   }
 
+  /**
+   * 메소드이름: findAllByUserId
+   *
+   * @parameter: userId - 조회할 사용자 UUID
+   * @return: 해당 사용자의 채널 목록
+   *
+   *          특정 사용자의 삭제되지 않은 채널 목록을 조회한다
+   */
   public List<Channel> findAllByUserId(UUID userId) {
     return channelRepository.findAllByUserId(userId);
   }
 
+  /**
+   * 메소드이름: delete
+   *
+   * @parameter: id - 삭제할 채널 UUID
+   *
+   *             채널을 소프트 삭제 처리한다 (deletedAt 설정)
+   */
   public void delete(UUID id) {
     Channel channel = channelRepository
         .findById(id)

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelType.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelType.java
@@ -1,5 +1,10 @@
 package com.nextdv.domain.channel;
 
+/**
+ * class: ChannelType 작성자: JBumLee
+ *
+ * 알림 채널 타입 열거형
+ */
 public enum ChannelType {
   SLACK, DISCORD, APP, EMAIL
 }

--- a/domain/src/main/java/com/nextdv/domain/channel/DiscordSender.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/DiscordSender.java
@@ -3,7 +3,20 @@ package com.nextdv.domain.channel;
 import com.nextdv.domain.healthcheck.ServiceStatus;
 import com.nextdv.domain.platform.Platform;
 
+/**
+ * class: DiscordSender 작성자: JBumLee
+ *
+ * Discord 웹훅 알림 발송 인터페이스
+ */
 public interface DiscordSender {
 
+  /**
+   * 메소드이름: send
+   *
+   * @parameter: webhookUrl - Discord 웹훅 URL, platform - 상태 변화된 플랫폼, newStatus -
+   *             변경된 상태
+   *
+   *             플랫폼 상태 변화를 Discord 채널에 알림으로 발송한다
+   */
   void send(String webhookUrl, Platform platform, ServiceStatus newStatus);
 }

--- a/domain/src/main/java/com/nextdv/domain/channel/EmailSender.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/EmailSender.java
@@ -3,7 +3,19 @@ package com.nextdv.domain.channel;
 import com.nextdv.domain.healthcheck.ServiceStatus;
 import com.nextdv.domain.platform.Platform;
 
+/**
+ * class: EmailSender 작성자: JBumLee
+ *
+ * 이메일 알림 발송 인터페이스
+ */
 public interface EmailSender {
 
+  /**
+   * 메소드이름: send
+   *
+   * @parameter: address - 수신자 이메일 주소, platform - 상태 변화된 플랫폼, newStatus - 변경된 상태
+   *
+   *             플랫폼 상태 변화를 이메일로 발송한다
+   */
   void send(String address, Platform platform, ServiceStatus newStatus);
 }

--- a/domain/src/main/java/com/nextdv/domain/channel/SlackSender.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/SlackSender.java
@@ -3,7 +3,20 @@ package com.nextdv.domain.channel;
 import com.nextdv.domain.healthcheck.ServiceStatus;
 import com.nextdv.domain.platform.Platform;
 
+/**
+ * class: SlackSender 작성자: JBumLee
+ *
+ * Slack 웹훅 알림 발송 인터페이스
+ */
 public interface SlackSender {
 
+  /**
+   * 메소드이름: send
+   *
+   * @parameter: webhookUrl - Slack 웹훅 URL, platform - 상태 변화된 플랫폼, newStatus - 변경된
+   *             상태
+   *
+   *             플랫폼 상태 변화를 Slack 채널에 알림으로 발송한다
+   */
   void send(String webhookUrl, Platform platform, ServiceStatus newStatus);
 }

--- a/domain/src/main/java/com/nextdv/domain/common/UuidV7.java
+++ b/domain/src/main/java/com/nextdv/domain/common/UuidV7.java
@@ -4,6 +4,11 @@ import com.fasterxml.uuid.Generators;
 import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import java.util.UUID;
 
+/**
+ * class: UuidV7 작성자: JBumLee
+ *
+ * 시간 순서가 보장되는 UUID v7 생성 유틸리티
+ */
 public final class UuidV7 {
 
   private static final TimeBasedEpochGenerator GENERATOR = Generators.timeBasedEpochGenerator();
@@ -11,6 +16,13 @@ public final class UuidV7 {
   private UuidV7() {
   }
 
+  /**
+   * 메소드이름: generate
+   *
+   * @return: 생성된 UUID v7 값
+   *
+   *          시간 기반 정렬 가능한 UUID v7을 생성한다
+   */
   public static UUID generate() {
     return GENERATOR.generate();
   }

--- a/domain/src/main/java/com/nextdv/domain/health/HealthResult.java
+++ b/domain/src/main/java/com/nextdv/domain/health/HealthResult.java
@@ -1,5 +1,10 @@
 package com.nextdv.domain.health;
 
+/**
+ * class: HealthResult 작성자: JBumLee
+ *
+ * 서버 헬스체크 결과 도메인 객체
+ */
 public class HealthResult {
 
   private final String status;

--- a/domain/src/main/java/com/nextdv/domain/health/HealthService.java
+++ b/domain/src/main/java/com/nextdv/domain/health/HealthService.java
@@ -2,9 +2,21 @@ package com.nextdv.domain.health;
 
 import org.springframework.stereotype.Service;
 
+/**
+ * class: HealthService 작성자: JBumLee
+ *
+ * 서버 헬스체크 상태를 반환하는 서비스
+ */
 @Service
 public class HealthService {
 
+  /**
+   * 메소드이름: check
+   *
+   * @return: 서버 헬스체크 결과
+   *
+   *          서버가 정상 동작 중임을 확인하는 헬스체크를 수행한다
+   */
   public HealthResult check() {
     return new HealthResult("ok");
   }

--- a/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLog.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLog.java
@@ -5,6 +5,11 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * class: HealthCheckLog 작성자: JBumLee
+ *
+ * 플랫폼 헬스체크 결과 로그 도메인 객체
+ */
 @Getter
 @AllArgsConstructor
 public class HealthCheckLog {

--- a/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLogRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLogRepository.java
@@ -4,11 +4,40 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * class: HealthCheckLogRepository 작성자: JBumLee
+ *
+ * 헬스체크 로그 도메인 저장소 인터페이스
+ */
 public interface HealthCheckLogRepository {
 
+  /**
+   * 메소드이름: save
+   *
+   * @parameter: log - 저장할 헬스체크 로그 객체
+   * @return: 저장된 헬스체크 로그 객체
+   *
+   *          헬스체크 로그를 저장한다
+   */
   HealthCheckLog save(HealthCheckLog log);
 
+  /**
+   * 메소드이름: findAllByPlatformId
+   *
+   * @parameter: platformId - 조회할 플랫폼 ID
+   * @return: 해당 플랫폼의 전체 헬스체크 로그 목록
+   *
+   *          특정 플랫폼의 모든 헬스체크 로그를 조회한다
+   */
   List<HealthCheckLog> findAllByPlatformId(UUID platformId);
 
+  /**
+   * 메소드이름: findLatestByPlatformId
+   *
+   * @parameter: platformId - 조회할 플랫폼 ID
+   * @return: 가장 최근 헬스체크 로그 (없으면 empty)
+   *
+   *          특정 플랫폼의 가장 최근 헬스체크 로그를 조회한다
+   */
   Optional<HealthCheckLog> findLatestByPlatformId(UUID platformId);
 }

--- a/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLogService.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLogService.java
@@ -6,16 +6,37 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * class: HealthCheckLogService 작성자: JBumLee
+ *
+ * 헬스체크 로그 조회 비즈니스 로직을 담당하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class HealthCheckLogService {
 
   private final HealthCheckLogRepository healthCheckLogRepository;
 
+  /**
+   * 메소드이름: findLatestByPlatformId
+   *
+   * @parameter: platformId - 조회할 플랫폼 ID
+   * @return: 가장 최근 헬스체크 로그 (없으면 empty)
+   *
+   *          특정 플랫폼의 최신 헬스체크 로그를 조회한다
+   */
   public Optional<HealthCheckLog> findLatestByPlatformId(UUID platformId) {
     return healthCheckLogRepository.findLatestByPlatformId(platformId);
   }
 
+  /**
+   * 메소드이름: findAllByPlatformId
+   *
+   * @parameter: platformId - 조회할 플랫폼 ID
+   * @return: 해당 플랫폼의 전체 헬스체크 로그 목록
+   *
+   *          특정 플랫폼의 모든 헬스체크 로그를 조회한다
+   */
   public List<HealthCheckLog> findAllByPlatformId(UUID platformId) {
     return healthCheckLogRepository.findAllByPlatformId(platformId);
   }

--- a/domain/src/main/java/com/nextdv/domain/healthcheck/ServiceStatus.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/ServiceStatus.java
@@ -1,14 +1,10 @@
 package com.nextdv.domain.healthcheck;
 
+/**
+ * class: ServiceStatus 작성자: JBumLee
+ *
+ * 서비스 상태를 나타내는 열거형
+ */
 public enum ServiceStatus {
-  /** 정상 운영 중 */
-  OPERATIONAL,
-  /** 응답 지연 등 성능 저하 */
-  DEGRADED,
-  /** 일부 기능 장애 */
-  PARTIAL_OUTAGE,
-  /** 전면 장애 */
-  MAJOR_OUTAGE,
-  /** 상태 미확인 */
-  UNKNOWN
+  OPERATIONAL, DEGRADED, PARTIAL_OUTAGE, MAJOR_OUTAGE, UNKNOWN
 }

--- a/domain/src/main/java/com/nextdv/domain/platform/Platform.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/Platform.java
@@ -3,6 +3,11 @@ package com.nextdv.domain.platform;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * class: Platform 작성자: JBumLee
+ *
+ * 헬스체크 대상 플랫폼 도메인 객체
+ */
 @Getter
 public class Platform {
 

--- a/domain/src/main/java/com/nextdv/domain/platform/PlatformRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/PlatformRepository.java
@@ -4,9 +4,30 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * class: PlatformRepository 작성자: JBumLee
+ *
+ * 플랫폼 도메인 저장소 인터페이스
+ */
 public interface PlatformRepository {
 
+  /**
+   * 메소드이름: findAll
+   *
+   * @parameter: activeOnly - true이면 활성화된 플랫폼만 조회
+   * @return: 플랫폼 목록
+   *
+   *          전체 또는 활성화된 플랫폼 목록을 조회한다
+   */
   List<Platform> findAll(boolean activeOnly);
 
+  /**
+   * 메소드이름: findById
+   *
+   * @parameter: id - 조회할 플랫폼 UUID
+   * @return: 플랫폼 객체 (없으면 empty)
+   *
+   *          ID로 플랫폼을 조회한다
+   */
   Optional<Platform> findById(UUID id);
 }

--- a/domain/src/main/java/com/nextdv/domain/platform/PlatformService.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/PlatformService.java
@@ -6,16 +6,36 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * class: PlatformService 작성자: JBumLee
+ *
+ * 플랫폼 조회 비즈니스 로직을 담당하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class PlatformService {
 
   private final PlatformRepository platformRepository;
 
+  /**
+   * 메소드이름: findAll
+   *
+   * @return: 활성화된 플랫폼 목록
+   *
+   *          활성화 상태인 플랫폼만 조회한다
+   */
   public List<Platform> findAll() {
     return platformRepository.findAll(true);
   }
 
+  /**
+   * 메소드이름: findById
+   *
+   * @parameter: id - 조회할 플랫폼 UUID
+   * @return: 플랫폼 객체 (없으면 empty)
+   *
+   *          ID로 플랫폼을 조회한다
+   */
   public Optional<Platform> findById(UUID id) {
     return platformRepository.findById(id);
   }

--- a/domain/src/main/java/com/nextdv/domain/platform/ServiceCategory.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/ServiceCategory.java
@@ -1,5 +1,10 @@
 package com.nextdv.domain.platform;
 
+/**
+ * class: ServiceCategory 작성자: JBumLee
+ *
+ * 플랫폼 서비스 카테고리 열거형
+ */
 public enum ServiceCategory {
   CLOUD, AI, COMMUNICATION, DEVTOOL, OTHER
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/JpaConfig.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/JpaConfig.java
@@ -4,6 +4,11 @@ import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+/**
+ * class: JpaConfig 작성자: JBumLee
+ *
+ * JPA Entity 스캔 및 Repository 활성화 설정
+ */
 @Configuration
 @EntityScan("com.nextdv.infrastructure")
 @EnableJpaRepositories("com.nextdv.infrastructure")

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/SchedulingConfig.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/SchedulingConfig.java
@@ -6,6 +6,11 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.client.RestClient;
 
+/**
+ * class: SchedulingConfig 작성자: JBumLee
+ *
+ * 스케줄링 활성화 및 헬스체크용 RestClient 빈 등록 설정
+ */
 @Configuration
 @EnableScheduling
 public class SchedulingConfig {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountEntity.java
@@ -6,6 +6,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
 
+/**
+ * class: AccountEntity 작성자: JBumLee
+ *
+ * accounts 테이블과 매핑되는 JPA 엔티티
+ */
 @Entity
 @Table(name = "accounts")
 public class AccountEntity {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountJpaRepository.java
@@ -3,6 +3,11 @@ package com.nextdv.infrastructure.account;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * class: AccountJpaRepository 작성자: JBumLee
+ *
+ * accounts 테이블 JPA 저장소 인터페이스
+ */
 public interface AccountJpaRepository
     extends
       JpaRepository<AccountEntity, UUID> {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountRepositoryImpl.java
@@ -7,6 +7,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Repository;
 
+/**
+ * class: AccountRepositoryImpl 작성자: JBumLee
+ *
+ * AccountRepository 인터페이스의 JPA 기반 구현체
+ */
 @Repository
 @RequiredArgsConstructor
 public class AccountRepositoryImpl implements AccountRepository {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelEntity.java
@@ -15,6 +15,11 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+/**
+ * class: ChannelEntity 작성자: JBumLee
+ *
+ * channels 테이블과 매핑되는 JPA 엔티티
+ */
 @Entity
 @Table(name = "channels")
 @Getter

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelJpaRepository.java
@@ -6,6 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+/**
+ * class: ChannelJpaRepository 작성자: JBumLee
+ *
+ * channels 테이블 JPA 저장소 인터페이스
+ */
 public interface ChannelJpaRepository extends JpaRepository<ChannelEntity, UUID> {
 
   List<ChannelEntity> findAllByUserIdAndDeletedAtIsNull(UUID userId);

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformEntity.java
@@ -8,6 +8,11 @@ import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * class: ChannelPlatformEntity 작성자: JBumLee
+ *
+ * channel_platforms 테이블과 매핑되는 JPA 엔티티
+ */
 @Getter
 @Entity
 @Table(name = "channel_platforms")

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformJpaRepository.java
@@ -3,6 +3,11 @@ package com.nextdv.infrastructure.channel;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * class: ChannelPlatformJpaRepository 작성자: JBumLee
+ *
+ * channel_platforms 테이블 JPA 저장소 인터페이스
+ */
 public interface ChannelPlatformJpaRepository extends JpaRepository<ChannelPlatformEntity, UUID> {
 
   boolean existsByChannelIdAndPlatformIdAndDeletedAtIsNull(UUID channelId, UUID platformId);

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformRepositoryImpl.java
@@ -6,6 +6,11 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+/**
+ * class: ChannelPlatformRepositoryImpl 작성자: JBumLee
+ *
+ * ChannelPlatformRepository 인터페이스의 JPA 기반 구현체
+ */
 @Repository
 @RequiredArgsConstructor
 public class ChannelPlatformRepositoryImpl implements ChannelPlatformRepository {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelRepositoryImpl.java
@@ -9,6 +9,11 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+/**
+ * class: ChannelRepositoryImpl 작성자: JBumLee
+ *
+ * ChannelRepository 인터페이스의 JPA 기반 구현체
+ */
 @Repository
 @RequiredArgsConstructor
 public class ChannelRepositoryImpl implements ChannelRepository {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelTypeEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelTypeEntity.java
@@ -1,5 +1,10 @@
 package com.nextdv.infrastructure.channel;
 
+/**
+ * class: ChannelTypeEntity 작성자: JBumLee
+ *
+ * DB 저장용 알림 채널 타입 열거형
+ */
 public enum ChannelTypeEntity {
   SLACK, DISCORD, APP, EMAIL
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogEntity.java
@@ -11,6 +11,11 @@ import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * class: HealthCheckLogEntity 작성자: JBumLee
+ *
+ * health_check_logs 테이블과 매핑되는 JPA 엔티티
+ */
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Entity

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogJpaRepository.java
@@ -5,6 +5,11 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * class: HealthCheckLogJpaRepository 작성자: JBumLee
+ *
+ * health_check_logs 테이블 JPA 저장소 인터페이스
+ */
 public interface HealthCheckLogJpaRepository extends JpaRepository<HealthCheckLogEntity, UUID> {
 
   List<HealthCheckLogEntity> findAllByPlatformId(UUID platformId);

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogRepositoryImpl.java
@@ -9,6 +9,11 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+/**
+ * class: HealthCheckLogRepositoryImpl 작성자: JBumLee
+ *
+ * HealthCheckLogRepository 인터페이스의 JPA 기반 구현체
+ */
 @Repository
 @RequiredArgsConstructor
 public class HealthCheckLogRepositoryImpl implements HealthCheckLogRepository {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
@@ -19,6 +19,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
+/**
+ * class: HealthCheckPollService 작성자: JBumLee
+ *
+ * 플랫폼 헬스체크 폴링 및 상태 변화 알림 발송을 담당하는 서비스
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -32,6 +37,11 @@ public class HealthCheckPollService {
   private final SlackSender slackSender;
   private final DiscordSender discordSender;
 
+  /**
+   * 메소드이름: pollAll
+   *
+   * 활성화된 모든 플랫폼에 대해 헬스체크를 수행한다
+   */
   public void pollAll() {
     platformService.findAll().forEach(this::poll);
   }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckScheduler.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckScheduler.java
@@ -4,12 +4,22 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+/**
+ * class: HealthCheckScheduler 작성자: JBumLee
+ *
+ * 주기적으로 헬스체크를 실행하는 스케줄러
+ */
 @Component
 @RequiredArgsConstructor
 public class HealthCheckScheduler {
 
   private final HealthCheckPollService healthCheckPollService;
 
+  /**
+   * 메소드이름: run
+   *
+   * 60초마다 모든 플랫폼에 대해 헬스체크를 실행한다
+   */
   @Scheduled(fixedDelay = 60_000)
   public void run() {
     healthCheckPollService.pollAll();

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/ServiceStatusEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/ServiceStatusEntity.java
@@ -1,14 +1,10 @@
 package com.nextdv.infrastructure.healthcheck;
 
+/**
+ * class: ServiceStatusEntity 작성자: JBumLee
+ *
+ * DB 저장용 서비스 상태 열거형
+ */
 public enum ServiceStatusEntity {
-  /** 정상 운영 중 */
-  OPERATIONAL,
-  /** 응답 지연 등 성능 저하 */
-  DEGRADED,
-  /** 일부 기능 장애 */
-  PARTIAL_OUTAGE,
-  /** 전면 장애 */
-  MAJOR_OUTAGE,
-  /** 상태 미확인 */
-  UNKNOWN
+  OPERATIONAL, DEGRADED, PARTIAL_OUTAGE, MAJOR_OUTAGE, UNKNOWN
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/notification/DiscordWebhookSender.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/notification/DiscordWebhookSender.java
@@ -9,6 +9,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+/**
+ * class: DiscordWebhookSender 작성자: JBumLee
+ *
+ * Discord 웹훅을 통해 플랫폼 상태 변화 알림을 발송하는 구현체
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -16,6 +21,14 @@ public class DiscordWebhookSender implements DiscordSender {
 
   private final RestClient restClient;
 
+  /**
+   * 메소드이름: send
+   *
+   * @parameter: webhookUrl - Discord 웹훅 URL, platform - 상태 변화된 플랫폼, newStatus -
+   *             변경된 상태
+   *
+   *             플랫폼 상태 변화 메시지를 Discord 채널에 POST 요청으로 발송한다
+   */
   @Override
   public void send(String webhookUrl, Platform platform, ServiceStatus newStatus) {
     String content = "[Heartbeat] " + platform.getName() + " 상태 변화: " + newStatus.name();

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SlackWebhookSender.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SlackWebhookSender.java
@@ -9,6 +9,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+/**
+ * class: SlackWebhookSender 작성자: JBumLee
+ *
+ * Slack 웹훅을 통해 플랫폼 상태 변화 알림을 발송하는 구현체
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -16,6 +21,14 @@ public class SlackWebhookSender implements SlackSender {
 
   private final RestClient restClient;
 
+  /**
+   * 메소드이름: send
+   *
+   * @parameter: webhookUrl - Slack 웹훅 URL, platform - 상태 변화된 플랫폼, newStatus - 변경된
+   *             상태
+   *
+   *             플랫폼 상태 변화 메시지를 Slack 채널에 POST 요청으로 발송한다
+   */
   @Override
   public void send(String webhookUrl, Platform platform, ServiceStatus newStatus) {
     String text = "[Heartbeat] " + platform.getName() + " 상태 변화: " + newStatus.name();

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SmtpEmailSender.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SmtpEmailSender.java
@@ -9,6 +9,11 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Component;
 
+/**
+ * class: SmtpEmailSender 작성자: JBumLee
+ *
+ * SMTP를 통해 플랫폼 상태 변화 알림 이메일을 발송하는 구현체
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -16,6 +21,13 @@ public class SmtpEmailSender implements EmailSender {
 
   private final JavaMailSender mailSender;
 
+  /**
+   * 메소드이름: send
+   *
+   * @parameter: address - 수신자 이메일 주소, platform - 상태 변화된 플랫폼, newStatus - 변경된 상태
+   *
+   *             플랫폼 상태 변화 내용을 이메일로 발송한다
+   */
   @Override
   public void send(String address, Platform platform, ServiceStatus newStatus) {
     SimpleMailMessage message = new SimpleMailMessage();

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformEntity.java
@@ -10,6 +10,11 @@ import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * class: PlatformEntity 작성자: JBumLee
+ *
+ * platforms 테이블과 매핑되는 JPA 엔티티
+ */
 @Getter
 @Entity
 @Table(name = "platforms")

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformJpaRepository.java
@@ -3,6 +3,11 @@ package com.nextdv.infrastructure.platform;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * class: PlatformJpaRepository 작성자: JBumLee
+ *
+ * platforms 테이블 JPA 저장소 인터페이스
+ */
 public interface PlatformJpaRepository
     extends
       JpaRepository<PlatformEntity, UUID> {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformRepositoryImpl.java
@@ -8,6 +8,11 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+/**
+ * class: PlatformRepositoryImpl 작성자: JBumLee
+ *
+ * PlatformRepository 인터페이스의 JPA 기반 구현체
+ */
 @Repository
 @RequiredArgsConstructor
 public class PlatformRepositoryImpl implements PlatformRepository {


### PR DESCRIPTION
## 변경 내용

- 모든 클래스/인터페이스에 팀 표준 JavaDoc 주석 형식 적용
  - 형식: `class: 이름 / 작성자: JBumLee / 클래스 설명`
  - 공개 메서드에 `메소드이름 / @parameter / @return / 의도` 형식 추가
  - 기존 enum 상수 위 불필요한 JavaDoc 5개 제거 (ServiceStatus, ServiceStatusEntity)
- Logback → Log4j2 교체
  - `spring-boot-starter-logging` 제외
  - `spring-boot-starter-log4j2` 추가
  - `log4j2.xml` 생성 (콘솔 출력, INFO 레벨)

## 참고

- 기존 `@Slf4j` 어노테이션 그대로 유지 (SLF4J 인터페이스는 변경 없음)
- API 변경 없음, DB 변경 없음

Closes #111
Closes #112