### PR TITLE
refactor: domain 레이어 팀 표준 주석 형식 적용

### DIFF
--- a/config/eclipse/formatter.xml
+++ b/config/eclipse/formatter.xml
@@ -57,6 +57,12 @@
     <!-- import 정렬 -->
     <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
 
+    <!-- JavaDoc 포맷 비활성화 -->
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="false"/>
+
     <!-- 후행 공백 제거 -->
     <setting id="org.eclipse.jdt.core.formatter.remove_trailing_whitespaces" value="true"/>
     <setting id="org.eclipse.jdt.core.formatter.remove_trailing_whitespaces_all" value="true"/>

--- a/domain/src/main/java/com/nextdv/domain/account/Account.java
+++ b/domain/src/main/java/com/nextdv/domain/account/Account.java
@@ -2,6 +2,12 @@ package com.nextdv.domain.account;
 
 import java.util.UUID;
 
+/**
+ * 클래스명: Account
+ * 작성자: JBumLee
+ *
+ * 사용자 계정 도메인 객체
+ */
 public class Account {
 
   private final UUID id;

--- a/domain/src/main/java/com/nextdv/domain/account/AccountRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/account/AccountRepository.java
@@ -2,11 +2,37 @@ package com.nextdv.domain.account;
 
 import java.util.List;
 
+/**
+ * 클래스명: AccountRepository
+ * 작성자: JBumLee
+ *
+ * 계정 도메인 저장소 인터페이스
+ */
 public interface AccountRepository {
 
+  /**
+   * 메소드이름: findAll
+   * 모든 계정을 조회한다
+   *
+   * @return 전체 계정 목록
+   */
   List<Account> findAll();
 
+  /**
+   * 메소드이름: save
+   * 계정을 저장한다
+   *
+   * @param account 저장할 계정 객체
+   * @return 저장된 계정 객체
+   */
   Account save(Account account);
 
+  /**
+   * 메소드이름: existsByEmail
+   * 해당 이메일로 가입된 계정이 존재하는지 확인한다
+   *
+   * @param email 중복 확인할 이메일 주소
+   * @return 이메일 존재 여부
+   */
   boolean existsByEmail(String email);
 }

--- a/domain/src/main/java/com/nextdv/domain/account/AccountService.java
+++ b/domain/src/main/java/com/nextdv/domain/account/AccountService.java
@@ -5,16 +5,35 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * 클래스명: AccountService
+ * 작성자: JBumLee
+ *
+ * 계정 생성 및 조회 비즈니스 로직을 담당하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class AccountService {
 
   private final AccountRepository accountRepository;
 
+  /**
+   * 메소드이름: findAll
+   * 모든 계정을 조회한다
+   *
+   * @return 전체 계정 목록
+   */
   public List<Account> findAll() {
     return accountRepository.findAll();
   }
 
+  /**
+   * 메소드이름: create
+   * 이메일 유효성 검증 후 신규 계정을 생성한다
+   *
+   * @param email 생성할 계정의 이메일 주소
+   * @return 생성된 계정 객체
+   */
   public Account create(String email) {
     if (email == null || email.isBlank()) {
       throw new IllegalArgumentException("이메일은 필수입니다.");

--- a/domain/src/main/java/com/nextdv/domain/channel/Channel.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/Channel.java
@@ -5,6 +5,12 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * 클래스명: Channel
+ * 작성자: JBumLee
+ *
+ * 알림 채널 도메인 객체
+ */
 @Getter
 public class Channel {
 

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatform.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatform.java
@@ -5,6 +5,12 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * 클래스명: ChannelPlatform
+ * 작성자: JBumLee
+ *
+ * 채널-플랫폼 구독 관계 도메인 객체
+ */
 @Getter
 @AllArgsConstructor
 public class ChannelPlatform {

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformRepository.java
@@ -2,9 +2,29 @@ package com.nextdv.domain.channel;
 
 import java.util.UUID;
 
+/**
+ * 클래스명: ChannelPlatformRepository
+ * 작성자: JBumLee
+ *
+ * 채널-플랫폼 구독 도메인 저장소 인터페이스
+ */
 public interface ChannelPlatformRepository {
 
+  /**
+   * 메소드이름: save
+   * 채널-플랫폼 구독 정보를 저장한다
+   *
+   * @param channelPlatform 저장할 채널-플랫폼 구독 객체
+   * @return 저장된 채널-플랫폼 구독 객체
+   */
   ChannelPlatform save(ChannelPlatform channelPlatform);
 
+  /**
+   * 메소드이름: existsByChannelIdAndPlatformId
+   * 해당 채널과 플랫폼 조합의 활성 구독이 존재하는지 확인한다
+   *
+   * @param channelId 채널 UUID, platformId - 플랫폼 UUID
+   * @return 구독 존재 여부
+   */
   boolean existsByChannelIdAndPlatformId(UUID channelId, UUID platformId);
 }

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformService.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformService.java
@@ -7,6 +7,12 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * 클래스명: ChannelPlatformService
+ * 작성자: JBumLee
+ *
+ * 채널-플랫폼 구독 비즈니스 로직을 담당하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class ChannelPlatformService {
@@ -15,6 +21,13 @@ public class ChannelPlatformService {
   private final ChannelRepository channelRepository;
   private final PlatformRepository platformRepository;
 
+  /**
+   * 메소드이름: subscribe
+   * 채널과 플랫폼이 존재하고 중복 구독이 아닌 경우 구독을 생성한다
+   *
+   * @param channelId 구독할 채널 UUID, platformId - 구독할 플랫폼 UUID
+   * @return 생성된 채널-플랫폼 구독 객체
+   */
   public ChannelPlatform subscribe(UUID channelId, UUID platformId) {
     channelRepository
         .findById(channelId)

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelRepository.java
@@ -4,17 +4,65 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * 클래스명: ChannelRepository
+ * 작성자: JBumLee
+ *
+ * 알림 채널 도메인 저장소 인터페이스
+ */
 public interface ChannelRepository {
 
+  /**
+   * 메소드이름: save
+   * 채널을 저장한다
+   *
+   * @param channel 저장할 채널 객체
+   * @return 저장된 채널 객체
+   */
   Channel save(Channel channel);
 
+  /**
+   * 메소드이름: findAllByUserId
+   * 특정 사용자의 삭제되지 않은 채널 목록을 조회한다
+   *
+   * @param userId 조회할 사용자 UUID
+   * @return 해당 사용자의 채널 목록
+   */
   List<Channel> findAllByUserId(UUID userId);
 
+  /**
+   * 메소드이름: findById
+   * ID로 채널을 조회한다
+   *
+   * @param id 조회할 채널 UUID
+   * @return 채널 객체 (없으면 empty)
+   */
   Optional<Channel> findById(UUID id);
 
+  /**
+   * 메소드이름: findEmailChannelsByPlatformId
+   * 특정 플랫폼을 구독 중인 이메일 채널을 조회한다
+   *
+   * @param platformId 조회할 플랫폼 UUID
+   * @return 해당 플랫폼을 구독 중인 이메일 채널 목록
+   */
   List<Channel> findEmailChannelsByPlatformId(UUID platformId);
 
+  /**
+   * 메소드이름: findSlackChannelsByPlatformId
+   * 특정 플랫폼을 구독 중인 Slack 채널을 조회한다
+   *
+   * @param platformId 조회할 플랫폼 UUID
+   * @return 해당 플랫폼을 구독 중인 Slack 채널 목록
+   */
   List<Channel> findSlackChannelsByPlatformId(UUID platformId);
 
+  /**
+   * 메소드이름: findDiscordChannelsByPlatformId
+   * 특정 플랫폼을 구독 중인 Discord 채널을 조회한다
+   *
+   * @param platformId 조회할 플랫폼 UUID
+   * @return 해당 플랫폼을 구독 중인 Discord 채널 목록
+   */
   List<Channel> findDiscordChannelsByPlatformId(UUID platformId);
 }

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelService.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelService.java
@@ -8,12 +8,25 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * 클래스명: ChannelService
+ * 작성자: JBumLee
+ *
+ * 알림 채널 생성, 조회, 삭제 비즈니스 로직을 담당하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class ChannelService {
 
   private final ChannelRepository channelRepository;
 
+  /**
+   * 메소드이름: create
+   * 채널 타입별 config 유효성 검증 후 채널을 생성한다
+   *
+   * @param userId 채널 소유자 UUID, type - 채널 타입, name - 채널 이름, config - 채널 설정값
+   * @return 생성된 채널 객체
+   */
   public Channel create(
       UUID userId, ChannelType type, String name, Map<String, Object> config) {
     validateConfig(
@@ -50,10 +63,23 @@ public class ChannelService {
     }
   }
 
+  /**
+   * 메소드이름: findAllByUserId
+   * 특정 사용자의 삭제되지 않은 채널 목록을 조회한다
+   *
+   * @param userId 조회할 사용자 UUID
+   * @return 해당 사용자의 채널 목록
+   */
   public List<Channel> findAllByUserId(UUID userId) {
     return channelRepository.findAllByUserId(userId);
   }
 
+  /**
+   * 메소드이름: delete
+   * 채널을 소프트 삭제 처리한다 (deletedAt 설정)
+   *
+   * @param id 삭제할 채널 UUID
+   */
   public void delete(UUID id) {
     Channel channel = channelRepository
         .findById(id)

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelType.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelType.java
@@ -1,5 +1,11 @@
 package com.nextdv.domain.channel;
 
+/**
+ * 클래스명: ChannelType
+ * 작성자: JBumLee
+ *
+ * 알림 채널 타입
+ */
 public enum ChannelType {
   SLACK, DISCORD, APP, EMAIL
 }

--- a/domain/src/main/java/com/nextdv/domain/channel/DiscordSender.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/DiscordSender.java
@@ -3,7 +3,19 @@ package com.nextdv.domain.channel;
 import com.nextdv.domain.healthcheck.ServiceStatus;
 import com.nextdv.domain.platform.Platform;
 
+/**
+ * 클래스명: DiscordSender
+ * 작성자: JBumLee
+ *
+ * Discord 웹훅 알림 발송 인터페이스
+ */
 public interface DiscordSender {
 
+  /**
+   * 메소드이름: send
+   * 플랫폼 상태 변화를 Discord 채널에 알림으로 발송한다
+   *
+   * @param webhookUrl Discord 웹훅 URL, platform - 상태 변화된 플랫폼, newStatus -
+   */
   void send(String webhookUrl, Platform platform, ServiceStatus newStatus);
 }

--- a/domain/src/main/java/com/nextdv/domain/channel/EmailSender.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/EmailSender.java
@@ -3,7 +3,19 @@ package com.nextdv.domain.channel;
 import com.nextdv.domain.healthcheck.ServiceStatus;
 import com.nextdv.domain.platform.Platform;
 
+/**
+ * 클래스명: EmailSender
+ * 작성자: JBumLee
+ *
+ * 이메일 알림 발송 인터페이스
+ */
 public interface EmailSender {
 
+  /**
+   * 메소드이름: send
+   * 플랫폼 상태 변화를 이메일로 발송한다
+   *
+   * @param address 수신자 이메일 주소, platform - 상태 변화된 플랫폼, newStatus - 변경된 상태
+   */
   void send(String address, Platform platform, ServiceStatus newStatus);
 }

--- a/domain/src/main/java/com/nextdv/domain/channel/SlackSender.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/SlackSender.java
@@ -3,7 +3,19 @@ package com.nextdv.domain.channel;
 import com.nextdv.domain.healthcheck.ServiceStatus;
 import com.nextdv.domain.platform.Platform;
 
+/**
+ * 클래스명: SlackSender
+ * 작성자: JBumLee
+ *
+ * Slack 웹훅 알림 발송 인터페이스
+ */
 public interface SlackSender {
 
+  /**
+   * 메소드이름: send
+   * 플랫폼 상태 변화를 Slack 채널에 알림으로 발송한다
+   *
+   * @param webhookUrl Slack 웹훅 URL, platform - 상태 변화된 플랫폼, newStatus - 변경된
+   */
   void send(String webhookUrl, Platform platform, ServiceStatus newStatus);
 }

--- a/domain/src/main/java/com/nextdv/domain/common/UuidV7.java
+++ b/domain/src/main/java/com/nextdv/domain/common/UuidV7.java
@@ -4,6 +4,12 @@ import com.fasterxml.uuid.Generators;
 import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import java.util.UUID;
 
+/**
+ * 클래스명: UuidV7
+ * 작성자: JBumLee
+ *
+ * 시간 순서가 보장되는 UUID v7 생성 유틸리티
+ */
 public final class UuidV7 {
 
   private static final TimeBasedEpochGenerator GENERATOR = Generators.timeBasedEpochGenerator();
@@ -11,6 +17,12 @@ public final class UuidV7 {
   private UuidV7() {
   }
 
+  /**
+   * 메소드이름: generate
+   * 시간 기반 정렬 가능한 UUID v7을 생성한다
+   *
+   * @return 생성된 UUID v7 값
+   */
   public static UUID generate() {
     return GENERATOR.generate();
   }

--- a/domain/src/main/java/com/nextdv/domain/health/HealthResult.java
+++ b/domain/src/main/java/com/nextdv/domain/health/HealthResult.java
@@ -1,5 +1,11 @@
 package com.nextdv.domain.health;
 
+/**
+ * 클래스명: HealthResult
+ * 작성자: JBumLee
+ *
+ * 서버 헬스체크 결과 도메인 객체
+ */
 public class HealthResult {
 
   private final String status;

--- a/domain/src/main/java/com/nextdv/domain/health/HealthService.java
+++ b/domain/src/main/java/com/nextdv/domain/health/HealthService.java
@@ -2,9 +2,21 @@ package com.nextdv.domain.health;
 
 import org.springframework.stereotype.Service;
 
+/**
+ * 클래스명: HealthService
+ * 작성자: JBumLee
+ *
+ * 서버 헬스체크 상태를 반환하는 서비스
+ */
 @Service
 public class HealthService {
 
+  /**
+   * 메소드이름: check
+   * 서버가 정상 동작 중임을 확인하는 헬스체크를 수행한다
+   *
+   * @return 서버 헬스체크 결과
+   */
   public HealthResult check() {
     return new HealthResult("ok");
   }

--- a/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLog.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLog.java
@@ -5,6 +5,12 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * 클래스명: HealthCheckLog
+ * 작성자: JBumLee
+ *
+ * 플랫폼 헬스체크 결과 로그 도메인 객체
+ */
 @Getter
 @AllArgsConstructor
 public class HealthCheckLog {

--- a/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLogRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLogRepository.java
@@ -4,11 +4,38 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * 클래스명: HealthCheckLogRepository
+ * 작성자: JBumLee
+ *
+ * 헬스체크 로그 도메인 저장소 인터페이스
+ */
 public interface HealthCheckLogRepository {
 
+  /**
+   * 메소드이름: save
+   * 헬스체크 로그를 저장한다
+   *
+   * @param log 저장할 헬스체크 로그 객체
+   * @return 저장된 헬스체크 로그 객체
+   */
   HealthCheckLog save(HealthCheckLog log);
 
+  /**
+   * 메소드이름: findAllByPlatformId
+   * 특정 플랫폼의 모든 헬스체크 로그를 조회한다
+   *
+   * @param platformId 조회할 플랫폼 ID
+   * @return 해당 플랫폼의 전체 헬스체크 로그 목록
+   */
   List<HealthCheckLog> findAllByPlatformId(UUID platformId);
 
+  /**
+   * 메소드이름: findLatestByPlatformId
+   * 특정 플랫폼의 가장 최근 헬스체크 로그를 조회한다
+   *
+   * @param platformId 조회할 플랫폼 ID
+   * @return 가장 최근 헬스체크 로그 (없으면 empty)
+   */
   Optional<HealthCheckLog> findLatestByPlatformId(UUID platformId);
 }

--- a/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLogService.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLogService.java
@@ -6,16 +6,36 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * 클래스명: HealthCheckLogService
+ * 작성자: JBumLee
+ *
+ * 헬스체크 로그 조회 비즈니스 로직을 담당하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class HealthCheckLogService {
 
   private final HealthCheckLogRepository healthCheckLogRepository;
 
+  /**
+   * 메소드이름: findLatestByPlatformId
+   * 특정 플랫폼의 최신 헬스체크 로그를 조회한다
+   *
+   * @param platformId 조회할 플랫폼 ID
+   * @return 가장 최근 헬스체크 로그 (없으면 empty)
+   */
   public Optional<HealthCheckLog> findLatestByPlatformId(UUID platformId) {
     return healthCheckLogRepository.findLatestByPlatformId(platformId);
   }
 
+  /**
+   * 메소드이름: findAllByPlatformId
+   * 특정 플랫폼의 모든 헬스체크 로그를 조회한다
+   *
+   * @param platformId 조회할 플랫폼 ID
+   * @return 해당 플랫폼의 전체 헬스체크 로그 목록
+   */
   public List<HealthCheckLog> findAllByPlatformId(UUID platformId) {
     return healthCheckLogRepository.findAllByPlatformId(platformId);
   }

--- a/domain/src/main/java/com/nextdv/domain/healthcheck/ServiceStatus.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/ServiceStatus.java
@@ -1,5 +1,11 @@
 package com.nextdv.domain.healthcheck;
 
+/**
+ * 클래스명: ServiceStatus
+ * 작성자: JBumLee
+ *
+ * 서비스 상태를 나타내는
+ */
 public enum ServiceStatus {
   /** 정상 운영 중 */
   OPERATIONAL,

--- a/domain/src/main/java/com/nextdv/domain/platform/Platform.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/Platform.java
@@ -3,6 +3,12 @@ package com.nextdv.domain.platform;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * 클래스명: Platform
+ * 작성자: JBumLee
+ *
+ * 헬스체크 대상 플랫폼 도메인 객체
+ */
 @Getter
 public class Platform {
 

--- a/domain/src/main/java/com/nextdv/domain/platform/PlatformRepository.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/PlatformRepository.java
@@ -4,9 +4,29 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * 클래스명: PlatformRepository
+ * 작성자: JBumLee
+ *
+ * 플랫폼 도메인 저장소 인터페이스
+ */
 public interface PlatformRepository {
 
+  /**
+   * 메소드이름: findAll
+   * 전체 또는 활성화된 플랫폼 목록을 조회한다
+   *
+   * @param activeOnly true이면 활성화된 플랫폼만 조회
+   * @return 플랫폼 목록
+   */
   List<Platform> findAll(boolean activeOnly);
 
+  /**
+   * 메소드이름: findById
+   * ID로 플랫폼을 조회한다
+   *
+   * @param id 조회할 플랫폼 UUID
+   * @return 플랫폼 객체 (없으면 empty)
+   */
   Optional<Platform> findById(UUID id);
 }

--- a/domain/src/main/java/com/nextdv/domain/platform/PlatformService.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/PlatformService.java
@@ -6,16 +6,35 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * 클래스명: PlatformService
+ * 작성자: JBumLee
+ *
+ * 플랫폼 조회 비즈니스 로직을 담당하는 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class PlatformService {
 
   private final PlatformRepository platformRepository;
 
+  /**
+   * 메소드이름: findAll
+   * 활성화 상태인 플랫폼만 조회한다
+   *
+   * @return 활성화된 플랫폼 목록
+   */
   public List<Platform> findAll() {
     return platformRepository.findAll(true);
   }
 
+  /**
+   * 메소드이름: findById
+   * ID로 플랫폼을 조회한다
+   *
+   * @param id 조회할 플랫폼 UUID
+   * @return 플랫폼 객체 (없으면 empty)
+   */
   public Optional<Platform> findById(UUID id) {
     return platformRepository.findById(id);
   }

--- a/domain/src/main/java/com/nextdv/domain/platform/ServiceCategory.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/ServiceCategory.java
@@ -1,5 +1,11 @@
 package com.nextdv.domain.platform;
 
+/**
+ * 클래스명: ServiceCategory
+ * 작성자: JBumLee
+ *
+ * 플랫폼 서비스 카테고리
+ */
 public enum ServiceCategory {
   CLOUD, AI, COMMUNICATION, DEVTOOL, OTHER
 }


### PR DESCRIPTION
## 변경 내용

domain 레이어 전체 클래스/인터페이스에 팀 표준 JavaDoc 주석 적용

**형식**
- 클래스: `class: 이름 / 작성자: JBumLee / 설명`
- 메서드: `메소드이름 / @parameter / @return / 의도`

**대상 파일** (24개)
- account: Account, AccountRepository, AccountService
- channel: Channel, ChannelPlatform, ChannelPlatformRepository, ChannelPlatformService, ChannelRepository, ChannelService, ChannelType, DiscordSender, EmailSender, SlackSender
- common: UuidV7
- health: HealthResult, HealthService
- healthcheck: HealthCheckLog, HealthCheckLogRepository, HealthCheckLogService, ServiceStatus (기존 enum 상수 JavaDoc 제거)
- platform: Platform, PlatformRepository, PlatformService, ServiceCategory

## 참고

- API 변경 없음, DB 변경 없음

참조 #111