### PR TITLE
refactor: api 레이어 팀 표준 주석 형식 적용

### DIFF
--- a/api/src/main/java/com/nextdv/api/HeartbeatApplication.java
+++ b/api/src/main/java/com/nextdv/api/HeartbeatApplication.java
@@ -3,6 +3,12 @@ package com.nextdv.api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * 클래스명: HeartbeatApplication
+ * 작성자: JBumLee
+ *
+ * Spring Boot 애플리케이션 진입점
+ */
 @SpringBootApplication(scanBasePackages = "com.nextdv")
 public class HeartbeatApplication {
 

--- a/api/src/main/java/com/nextdv/api/account/AccountController.java
+++ b/api/src/main/java/com/nextdv/api/account/AccountController.java
@@ -15,6 +15,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 클래스명: AccountController
+ * 작성자: JBumLee
+ *
+ * 계정 관련 REST API 엔드포인트를 제공하는 컨트롤러
+ */
 @RestController
 @RequestMapping("/accounts")
 @RequiredArgsConstructor
@@ -22,6 +28,12 @@ public class AccountController {
 
   private final AccountService accountService;
 
+  /**
+   * 메소드이름: list
+   * 등록된 모든 계정을 조회한다
+   *
+   * @return 전체 계정 목록 응답
+   */
   @GetMapping
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<List<AccountResponse>>> list() {
@@ -30,6 +42,13 @@ public class AccountController {
     return ResponseEntity.ok(CommonResponse.ok(data));
   }
 
+  /**
+   * 메소드이름: create
+   * 이메일로 신규 계정을 생성한다
+   *
+   * @param request 계정 생성 요청 (이메일 포함)
+   * @return 생성된 계정 응답
+   */
   @PostMapping
   @ApiResponse(responseCode = "400", description = "이메일 필드 누락 또는 이메일 형식 오류")
   @ApiResponse(responseCode = "409", description = "이미 사용 중인 이메일")

--- a/api/src/main/java/com/nextdv/api/account/AccountMapper.java
+++ b/api/src/main/java/com/nextdv/api/account/AccountMapper.java
@@ -3,15 +3,35 @@ package com.nextdv.api.account;
 import com.nextdv.domain.account.Account;
 import java.util.List;
 
+/**
+ * 클래스명: AccountMapper
+ * 작성자: JBumLee
+ *
+ * Account 도메인 객체를 AccountResponse DTO로 변환하는 매퍼
+ */
 public class AccountMapper {
 
   private AccountMapper() {
   }
 
+  /**
+   * 메소드이름: toResponse
+   * Account 도메인 객체를 응답 DTO로 변환한다
+   *
+   * @param account 변환할 계정 도메인 객체
+   * @return AccountResponse DTO
+   */
   public static AccountResponse toResponse(Account account) {
     return new AccountResponse(account.getId(), account.getEmail());
   }
 
+  /**
+   * 메소드이름: toResponseList
+   * Account 도메인 객체 목록을 응답 DTO 목록으로 변환한다
+   *
+   * @param accounts 변환할 계정 도메인 객체 목록
+   * @return AccountResponse DTO 목록
+   */
   public static List<AccountResponse> toResponseList(
       List<Account> accounts) {
     return accounts.stream().map(AccountMapper::toResponse).toList();

--- a/api/src/main/java/com/nextdv/api/account/AccountRequest.java
+++ b/api/src/main/java/com/nextdv/api/account/AccountRequest.java
@@ -3,6 +3,12 @@ package com.nextdv.api.account;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
+/**
+ * 클래스명: AccountRequest
+ * 작성자: JBumLee
+ *
+ * 계정 생성 요청 DTO
+ */
 public class AccountRequest {
 
   @NotBlank(message = "이메일은 필수입니다.")

--- a/api/src/main/java/com/nextdv/api/account/AccountResponse.java
+++ b/api/src/main/java/com/nextdv/api/account/AccountResponse.java
@@ -2,6 +2,12 @@ package com.nextdv.api.account;
 
 import java.util.UUID;
 
+/**
+ * 클래스명: AccountResponse
+ * 작성자: JBumLee
+ *
+ * 계정 조회 응답 DTO
+ */
 public class AccountResponse {
 
   private final UUID id;

--- a/api/src/main/java/com/nextdv/api/channel/ChannelController.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelController.java
@@ -18,6 +18,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 클래스명: ChannelController
+ * 작성자: JBumLee
+ *
+ * 알림 채널 관련 REST API 엔드포인트를 제공하는 컨트롤러
+ */
 @RestController
 @RequestMapping("/channels")
 public class ChannelController {
@@ -28,6 +34,13 @@ public class ChannelController {
     this.channelService = channelService;
   }
 
+  /**
+   * 메소드이름: create
+   * 새로운 알림 채널을 생성한다
+   *
+   * @param request 채널 생성 요청 (userId, type, name, config 포함)
+   * @return 생성된 채널 응답
+   */
   @PostMapping
   @ApiResponse(responseCode = "400", description = "userId, type, name, config 필수 필드 누락 또는 형식 오류")
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
@@ -43,6 +56,13 @@ public class ChannelController {
         .body(CommonResponse.ok(ChannelMapper.toResponse(channel)));
   }
 
+  /**
+   * 메소드이름: list
+   * 특정 사용자의 알림 채널 목록을 조회한다
+   *
+   * @param userId 채널 소유자 UUID
+   * @return 해당 사용자의 채널 목록 응답
+   */
   @GetMapping
   @ApiResponse(responseCode = "400", description = "userId 파라미터 누락 또는 UUID 형식이 아님")
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
@@ -51,6 +71,13 @@ public class ChannelController {
     return ResponseEntity.ok(CommonResponse.ok(ChannelMapper.toResponseList(channels)));
   }
 
+  /**
+   * 메소드이름: delete
+   * 알림 채널을 소프트 삭제 처리한다
+   *
+   * @param id 삭제할 채널 UUID
+   * @return 성공 응답
+   */
   @DeleteMapping("/{id}")
   @ApiResponse(responseCode = "400", description = "id가 UUID 형식이 아님")
   @ApiResponse(responseCode = "404", description = "해당 ID에 해당하는 채널이 존재하지 않음")

--- a/api/src/main/java/com/nextdv/api/channel/ChannelMapper.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelMapper.java
@@ -3,8 +3,21 @@ package com.nextdv.api.channel;
 import com.nextdv.domain.channel.Channel;
 import java.util.List;
 
+/**
+ * 클래스명: ChannelMapper
+ * 작성자: JBumLee
+ *
+ * Channel 도메인 객체를 ChannelResponse DTO로 변환하는 매퍼
+ */
 public class ChannelMapper {
 
+  /**
+   * 메소드이름: toResponse
+   * Channel 도메인 객체를 응답 DTO로 변환한다
+   *
+   * @param channel 변환할 채널 도메인 객체
+   * @return ChannelResponse DTO
+   */
   public static ChannelResponse toResponse(Channel channel) {
     return new ChannelResponse(
         channel.getId(),
@@ -16,6 +29,13 @@ public class ChannelMapper {
     );
   }
 
+  /**
+   * 메소드이름: toResponseList
+   * Channel 도메인 객체 목록을 응답 DTO 목록으로 변환한다
+   *
+   * @param channels 변환할 채널 도메인 객체 목록
+   * @return ChannelResponse DTO 목록
+   */
   public static List<ChannelResponse> toResponseList(List<Channel> channels) {
     return channels.stream().map(ChannelMapper::toResponse).toList();
   }

--- a/api/src/main/java/com/nextdv/api/channel/ChannelPlatformController.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelPlatformController.java
@@ -12,6 +12,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 클래스명: ChannelPlatformController
+ * 작성자: JBumLee
+ *
+ * 채널-플랫폼 구독 관련 REST API 엔드포인트를 제공하는 컨트롤러
+ */
 @RestController
 @RequestMapping("/channel-platforms")
 public class ChannelPlatformController {
@@ -22,6 +28,13 @@ public class ChannelPlatformController {
     this.channelPlatformService = channelPlatformService;
   }
 
+  /**
+   * 메소드이름: subscribe
+   * 채널과 플랫폼을 연결하는 구독을 생성한다
+   *
+   * @param request 구독 요청 (channelId, platformId 포함)
+   * @return 생성된 구독 정보 응답
+   */
   @PostMapping
   @ApiResponse(responseCode = "400", description = "channelId 또는 platformId 누락 또는 UUID 형식이 아님")
   @ApiResponse(responseCode = "404", description = "해당 channelId 또는 platformId에 해당하는 리소스가 존재하지 않음")

--- a/api/src/main/java/com/nextdv/api/channel/ChannelPlatformRequest.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelPlatformRequest.java
@@ -4,6 +4,12 @@ import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * 클래스명: ChannelPlatformRequest
+ * 작성자: JBumLee
+ *
+ * 채널-플랫폼 구독 생성 요청 DTO
+ */
 @Getter
 public class ChannelPlatformRequest {
 

--- a/api/src/main/java/com/nextdv/api/channel/ChannelPlatformResponse.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelPlatformResponse.java
@@ -6,6 +6,12 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * 클래스명: ChannelPlatformResponse
+ * 작성자: JBumLee
+ *
+ * 채널-플랫폼 구독 정보 응답 DTO
+ */
 @Getter
 @AllArgsConstructor
 public class ChannelPlatformResponse {
@@ -15,6 +21,13 @@ public class ChannelPlatformResponse {
   private UUID platformId;
   private Instant createdAt;
 
+  /**
+   * 메소드이름: from
+   * ChannelPlatform 도메인 객체를 응답 DTO로 변환한다
+   *
+   * @param channelPlatform 변환할 채널-플랫폼 도메인 객체
+   * @return ChannelPlatformResponse DTO
+   */
   public static ChannelPlatformResponse from(ChannelPlatform channelPlatform) {
     return new ChannelPlatformResponse(
         channelPlatform.getId(),

--- a/api/src/main/java/com/nextdv/api/channel/ChannelRequest.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelRequest.java
@@ -7,6 +7,12 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * 클래스명: ChannelRequest
+ * 작성자: JBumLee
+ *
+ * 채널 생성 요청 DTO
+ */
 @Getter
 public class ChannelRequest {
 

--- a/api/src/main/java/com/nextdv/api/channel/ChannelResponse.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelResponse.java
@@ -5,6 +5,12 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * 클래스명: ChannelResponse
+ * 작성자: JBumLee
+ *
+ * 채널 조회 응답 DTO
+ */
 public class ChannelResponse {
 
   private final UUID id;

--- a/api/src/main/java/com/nextdv/api/common/CommonResponse.java
+++ b/api/src/main/java/com/nextdv/api/common/CommonResponse.java
@@ -1,5 +1,11 @@
 package com.nextdv.api.common;
 
+/**
+ * 클래스명: CommonResponse
+ * 작성자: JBumLee
+ *
+ * API 공통 응답 래퍼 클래스
+ */
 public class CommonResponse<T> {
 
   private final boolean success;
@@ -12,14 +18,35 @@ public class CommonResponse<T> {
     this.message = message;
   }
 
+  /**
+   * 메소드이름: ok
+   * 데이터를 포함한 성공 응답을 생성한다
+   *
+   * @param data 응답 데이터
+   * @return 성공 응답 객체
+   */
   public static <T> CommonResponse<T> ok(T data) {
     return new CommonResponse<>(true, data, null);
   }
 
+  /**
+   * 메소드이름: ok
+   * 데이터와 메시지를 포함한 성공 응답을 생성한다
+   *
+   * @param data 응답 데이터, message - 응답 메시지
+   * @return 성공 응답 객체
+   */
   public static <T> CommonResponse<T> ok(T data, String message) {
     return new CommonResponse<>(true, data, message);
   }
 
+  /**
+   * 메소드이름: fail
+   * 실패 메시지를 포함한 실패 응답을 생성한다
+   *
+   * @param message 실패 메시지
+   * @return 실패 응답 객체
+   */
   public static <T> CommonResponse<T> fail(String message) {
     return new CommonResponse<>(false, null, message);
   }

--- a/api/src/main/java/com/nextdv/api/common/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/nextdv/api/common/GlobalExceptionHandler.java
@@ -11,6 +11,12 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+/**
+ * 클래스명: GlobalExceptionHandler
+ * 작성자: JBumLee
+ *
+ * 전역 예외를 처리하여 공통 응답 형식으로 변환하는 핸들러
+ */
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {

--- a/api/src/main/java/com/nextdv/api/common/SwaggerConfig.java
+++ b/api/src/main/java/com/nextdv/api/common/SwaggerConfig.java
@@ -7,6 +7,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * 클래스명: SwaggerConfig
+ * 작성자: JBumLee
+ *
+ * Swagger UI 서버 URL 설정 (Traefik/Cloudflare 환경에서 https 강제)
+ */
 @Configuration
 public class SwaggerConfig {
 

--- a/api/src/main/java/com/nextdv/api/health/HealthController.java
+++ b/api/src/main/java/com/nextdv/api/health/HealthController.java
@@ -10,6 +10,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 클래스명: HealthController
+ * 작성자: JBumLee
+ *
+ * 서버 헬스체크 엔드포인트를 제공하는 컨트롤러
+ */
 @RestController
 @RequestMapping("/health")
 @RequiredArgsConstructor
@@ -17,6 +23,12 @@ public class HealthController {
 
   private final HealthService healthService;
 
+  /**
+   * 메소드이름: health
+   * 서버가 정상 동작 중인지 확인하는 헬스체크를 수행한다
+   *
+   * @return 서버 상태 응답
+   */
   @GetMapping
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<HealthResponse>> health() {

--- a/api/src/main/java/com/nextdv/api/health/HealthMapper.java
+++ b/api/src/main/java/com/nextdv/api/health/HealthMapper.java
@@ -2,11 +2,24 @@ package com.nextdv.api.health;
 
 import com.nextdv.domain.health.HealthResult;
 
+/**
+ * 클래스명: HealthMapper
+ * 작성자: JBumLee
+ *
+ * HealthResult 도메인 객체를 HealthResponse DTO로 변환하는 매퍼
+ */
 public class HealthMapper {
 
   private HealthMapper() {
   }
 
+  /**
+   * 메소드이름: toResponse
+   * HealthResult 도메인 객체를 응답 DTO로 변환한다
+   *
+   * @param result 변환할 헬스체크 결과 도메인 객체
+   * @return HealthResponse DTO
+   */
   public static HealthResponse toResponse(HealthResult result) {
     return new HealthResponse(result.getStatus());
   }

--- a/api/src/main/java/com/nextdv/api/health/HealthResponse.java
+++ b/api/src/main/java/com/nextdv/api/health/HealthResponse.java
@@ -1,5 +1,11 @@
 package com.nextdv.api.health;
 
+/**
+ * 클래스명: HealthResponse
+ * 작성자: JBumLee
+ *
+ * 서버 헬스체크 응답 DTO
+ */
 public class HealthResponse {
 
   private final String status;

--- a/api/src/main/java/com/nextdv/api/healthcheck/HealthCheckLogMapper.java
+++ b/api/src/main/java/com/nextdv/api/healthcheck/HealthCheckLogMapper.java
@@ -3,8 +3,21 @@ package com.nextdv.api.healthcheck;
 import com.nextdv.domain.healthcheck.HealthCheckLog;
 import java.util.List;
 
+/**
+ * 클래스명: HealthCheckLogMapper
+ * 작성자: JBumLee
+ *
+ * HealthCheckLog 도메인 객체를 HealthCheckLogResponse DTO로 변환하는 매퍼
+ */
 public class HealthCheckLogMapper {
 
+  /**
+   * 메소드이름: toResponse
+   * HealthCheckLog 도메인 객체를 응답 DTO로 변환한다
+   *
+   * @param log 변환할 헬스체크 로그 도메인 객체
+   * @return HealthCheckLogResponse DTO
+   */
   public static HealthCheckLogResponse toResponse(HealthCheckLog log) {
     return new HealthCheckLogResponse(
         log.getId(),
@@ -15,6 +28,13 @@ public class HealthCheckLogMapper {
     );
   }
 
+  /**
+   * 메소드이름: toResponseList
+   * HealthCheckLog 도메인 객체 목록을 응답 DTO 목록으로 변환한다
+   *
+   * @param logs 변환할 헬스체크 로그 도메인 객체 목록
+   * @return HealthCheckLogResponse DTO 목록
+   */
   public static List<HealthCheckLogResponse> toResponseList(List<HealthCheckLog> logs) {
     return logs.stream().map(HealthCheckLogMapper::toResponse).toList();
   }

--- a/api/src/main/java/com/nextdv/api/healthcheck/HealthCheckLogResponse.java
+++ b/api/src/main/java/com/nextdv/api/healthcheck/HealthCheckLogResponse.java
@@ -6,6 +6,12 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * 클래스명: HealthCheckLogResponse
+ * 작성자: JBumLee
+ *
+ * 헬스체크 로그 응답 DTO
+ */
 @Getter
 @AllArgsConstructor
 public class HealthCheckLogResponse {

--- a/api/src/main/java/com/nextdv/api/healthcheck/PlatformStatusController.java
+++ b/api/src/main/java/com/nextdv/api/healthcheck/PlatformStatusController.java
@@ -14,6 +14,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 클래스명: PlatformStatusController
+ * 작성자: JBumLee
+ *
+ * 플랫폼 헬스체크 상태 조회 REST API 엔드포인트를 제공하는 컨트롤러
+ */
 @RestController
 @RequestMapping("/platforms")
 @RequiredArgsConstructor
@@ -22,6 +28,13 @@ public class PlatformStatusController {
   private final HealthCheckLogService healthCheckLogService;
   private final PlatformService platformService;
 
+  /**
+   * 메소드이름: getStatus
+   * 특정 플랫폼의 최신 헬스체크 상태를 조회한다
+   *
+   * @param id 조회할 플랫폼 UUID
+   * @return 가장 최근 헬스체크 상태 응답
+   */
   @GetMapping("/{id}/status")
   @ApiResponse(responseCode = "400", description = "id가 UUID 형식이 아님")
   @ApiResponse(responseCode = "404", description = "해당 ID에 해당하는 플랫폼이 존재하지 않음")
@@ -36,6 +49,13 @@ public class PlatformStatusController {
         .orElse(ResponseEntity.ok(CommonResponse.ok(null)));
   }
 
+  /**
+   * 메소드이름: getLogs
+   * 특정 플랫폼의 모든 헬스체크 로그를 조회한다
+   *
+   * @param id 조회할 플랫폼 UUID
+   * @return 전체 헬스체크 로그 응답 목록
+   */
   @GetMapping("/{id}/logs")
   @ApiResponse(responseCode = "400", description = "id가 UUID 형식이 아님")
   @ApiResponse(responseCode = "404", description = "해당 ID에 해당하는 플랫폼이 존재하지 않음")

--- a/api/src/main/java/com/nextdv/api/platform/PlatformController.java
+++ b/api/src/main/java/com/nextdv/api/platform/PlatformController.java
@@ -14,6 +14,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 클래스명: PlatformController
+ * 작성자: JBumLee
+ *
+ * 플랫폼 조회 REST API 엔드포인트를 제공하는 컨트롤러
+ */
 @RestController
 @RequestMapping("/platforms")
 @RequiredArgsConstructor
@@ -21,6 +27,12 @@ public class PlatformController {
 
   private final PlatformService platformService;
 
+  /**
+   * 메소드이름: list
+   * 활성화 상태인 모든 플랫폼을 조회한다
+   *
+   * @return 활성화된 플랫폼 목록 응답
+   */
   @GetMapping
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<List<PlatformResponse>>> list() {
@@ -28,6 +40,13 @@ public class PlatformController {
     return ResponseEntity.ok(CommonResponse.ok(PlatformMapper.toResponseList(platforms)));
   }
 
+  /**
+   * 메소드이름: findById
+   * ID로 특정 플랫폼을 조회한다
+   *
+   * @param id 조회할 플랫폼 UUID
+   * @return 플랫폼 응답
+   */
   @GetMapping("/{id}")
   @ApiResponse(responseCode = "400", description = "id가 UUID 형식이 아님")
   @ApiResponse(responseCode = "404", description = "해당 ID에 해당하는 플랫폼이 존재하지 않음")

--- a/api/src/main/java/com/nextdv/api/platform/PlatformMapper.java
+++ b/api/src/main/java/com/nextdv/api/platform/PlatformMapper.java
@@ -3,11 +3,24 @@ package com.nextdv.api.platform;
 import com.nextdv.domain.platform.Platform;
 import java.util.List;
 
+/**
+ * 클래스명: PlatformMapper
+ * 작성자: JBumLee
+ *
+ * Platform 도메인 객체를 PlatformResponse DTO로 변환하는 매퍼
+ */
 public class PlatformMapper {
 
   private PlatformMapper() {
   }
 
+  /**
+   * 메소드이름: toResponse
+   * Platform 도메인 객체를 응답 DTO로 변환한다
+   *
+   * @param platform 변환할 플랫폼 도메인 객체
+   * @return PlatformResponse DTO
+   */
   public static PlatformResponse toResponse(Platform platform) {
     return new PlatformResponse(
         platform.getId(),
@@ -21,6 +34,13 @@ public class PlatformMapper {
     );
   }
 
+  /**
+   * 메소드이름: toResponseList
+   * Platform 도메인 객체 목록을 응답 DTO 목록으로 변환한다
+   *
+   * @param platforms 변환할 플랫폼 도메인 객체 목록
+   * @return PlatformResponse DTO 목록
+   */
   public static List<PlatformResponse> toResponseList(List<Platform> platforms) {
     return platforms.stream()
         .map(PlatformMapper::toResponse)

--- a/api/src/main/java/com/nextdv/api/platform/PlatformResponse.java
+++ b/api/src/main/java/com/nextdv/api/platform/PlatformResponse.java
@@ -4,6 +4,12 @@ import com.nextdv.domain.platform.ServiceCategory;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * 클래스명: PlatformResponse
+ * 작성자: JBumLee
+ *
+ * 플랫폼 조회 응답 DTO
+ */
 @Getter
 public class PlatformResponse {
 

--- a/config/eclipse/formatter.xml
+++ b/config/eclipse/formatter.xml
@@ -57,6 +57,12 @@
     <!-- import 정렬 -->
     <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
 
+    <!-- JavaDoc 포맷 비활성화 -->
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="false"/>
+
     <!-- 후행 공백 제거 -->
     <setting id="org.eclipse.jdt.core.formatter.remove_trailing_whitespaces" value="true"/>
     <setting id="org.eclipse.jdt.core.formatter.remove_trailing_whitespaces_all" value="true"/>


### PR DESCRIPTION
## 변경 내용

api 레이어 전체 클래스/인터페이스에 팀 표준 JavaDoc 주석 적용

**형식**
- 클래스: `class: 이름 / 작성자: JBumLee / 설명`
- 메서드: `메소드이름 / @parameter / @return / 의도`

**대상 파일** (24개)
- HeartbeatApplication
- account: AccountController, AccountMapper, AccountRequest, AccountResponse
- channel: ChannelController, ChannelMapper, ChannelPlatformController, ChannelPlatformRequest, ChannelPlatformResponse, ChannelRequest, ChannelResponse
- common: CommonResponse, GlobalExceptionHandler, SwaggerConfig
- health: HealthController, HealthMapper, HealthResponse
- healthcheck: HealthCheckLogMapper, HealthCheckLogResponse, PlatformStatusController
- platform: PlatformController, PlatformMapper, PlatformResponse

## 참고

- API 변경 없음, DB 변경 없음

참조 #111