### PR TITLE
refactor: infrastructure 레이어 팀 표준 주석 형식 적용

### DIFF
--- a/config/eclipse/formatter.xml
+++ b/config/eclipse/formatter.xml
@@ -57,6 +57,12 @@
     <!-- import 정렬 -->
     <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
 
+    <!-- JavaDoc 포맷 비활성화 -->
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="false"/>
+
     <!-- 후행 공백 제거 -->
     <setting id="org.eclipse.jdt.core.formatter.remove_trailing_whitespaces" value="true"/>
     <setting id="org.eclipse.jdt.core.formatter.remove_trailing_whitespaces_all" value="true"/>

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/JpaConfig.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/JpaConfig.java
@@ -4,6 +4,12 @@ import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+/**
+ * 클래스명: JpaConfig
+ * 작성자: JBumLee
+ *
+ * JPA Entity 스캔 및 Repository 활성화 설정
+ */
 @Configuration
 @EntityScan("com.nextdv.infrastructure")
 @EnableJpaRepositories("com.nextdv.infrastructure")

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/SchedulingConfig.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/SchedulingConfig.java
@@ -6,6 +6,12 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.client.RestClient;
 
+/**
+ * 클래스명: SchedulingConfig
+ * 작성자: JBumLee
+ *
+ * 스케줄링 활성화 및 헬스체크용 RestClient 빈 등록 설정
+ */
 @Configuration
 @EnableScheduling
 public class SchedulingConfig {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountEntity.java
@@ -6,6 +6,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
 
+/**
+ * 클래스명: AccountEntity
+ * 작성자: JBumLee
+ *
+ * accounts 테이블과 매핑되는 JPA 엔티티
+ */
 @Entity
 @Table(name = "accounts")
 public class AccountEntity {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountJpaRepository.java
@@ -3,6 +3,12 @@ package com.nextdv.infrastructure.account;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * 클래스명: AccountJpaRepository
+ * 작성자: JBumLee
+ *
+ * accounts 테이블 JPA 저장소 인터페이스
+ */
 public interface AccountJpaRepository
     extends
       JpaRepository<AccountEntity, UUID> {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/account/AccountRepositoryImpl.java
@@ -7,6 +7,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Repository;
 
+/**
+ * 클래스명: AccountRepositoryImpl
+ * 작성자: JBumLee
+ *
+ * AccountRepository 인터페이스의 JPA 기반 구현체
+ */
 @Repository
 @RequiredArgsConstructor
 public class AccountRepositoryImpl implements AccountRepository {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelEntity.java
@@ -15,6 +15,12 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+/**
+ * 클래스명: ChannelEntity
+ * 작성자: JBumLee
+ *
+ * channels 테이블과 매핑되는 JPA 엔티티
+ */
 @Entity
 @Table(name = "channels")
 @Getter

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelJpaRepository.java
@@ -6,6 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+/**
+ * 클래스명: ChannelJpaRepository
+ * 작성자: JBumLee
+ *
+ * channels 테이블 JPA 저장소 인터페이스
+ */
 public interface ChannelJpaRepository extends JpaRepository<ChannelEntity, UUID> {
 
   List<ChannelEntity> findAllByUserIdAndDeletedAtIsNull(UUID userId);

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformEntity.java
@@ -8,6 +8,12 @@ import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * 클래스명: ChannelPlatformEntity
+ * 작성자: JBumLee
+ *
+ * channel_platforms 테이블과 매핑되는 JPA 엔티티
+ */
 @Getter
 @Entity
 @Table(name = "channel_platforms")

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformJpaRepository.java
@@ -3,6 +3,12 @@ package com.nextdv.infrastructure.channel;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * 클래스명: ChannelPlatformJpaRepository
+ * 작성자: JBumLee
+ *
+ * channel_platforms 테이블 JPA 저장소 인터페이스
+ */
 public interface ChannelPlatformJpaRepository extends JpaRepository<ChannelPlatformEntity, UUID> {
 
   boolean existsByChannelIdAndPlatformIdAndDeletedAtIsNull(UUID channelId, UUID platformId);

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelPlatformRepositoryImpl.java
@@ -6,6 +6,12 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+/**
+ * 클래스명: ChannelPlatformRepositoryImpl
+ * 작성자: JBumLee
+ *
+ * ChannelPlatformRepository 인터페이스의 JPA 기반 구현체
+ */
 @Repository
 @RequiredArgsConstructor
 public class ChannelPlatformRepositoryImpl implements ChannelPlatformRepository {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelRepositoryImpl.java
@@ -9,6 +9,12 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+/**
+ * 클래스명: ChannelRepositoryImpl
+ * 작성자: JBumLee
+ *
+ * ChannelRepository 인터페이스의 JPA 기반 구현체
+ */
 @Repository
 @RequiredArgsConstructor
 public class ChannelRepositoryImpl implements ChannelRepository {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelTypeEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/channel/ChannelTypeEntity.java
@@ -1,5 +1,11 @@
 package com.nextdv.infrastructure.channel;
 
+/**
+ * 클래스명: ChannelTypeEntity
+ * 작성자: JBumLee
+ *
+ * DB 저장용 알림 채널 타입
+ */
 public enum ChannelTypeEntity {
   SLACK, DISCORD, APP, EMAIL
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogEntity.java
@@ -11,6 +11,12 @@ import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 클래스명: HealthCheckLogEntity
+ * 작성자: JBumLee
+ *
+ * health_check_logs 테이블과 매핑되는 JPA 엔티티
+ */
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Entity

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogJpaRepository.java
@@ -5,6 +5,12 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * 클래스명: HealthCheckLogJpaRepository
+ * 작성자: JBumLee
+ *
+ * health_check_logs 테이블 JPA 저장소 인터페이스
+ */
 public interface HealthCheckLogJpaRepository extends JpaRepository<HealthCheckLogEntity, UUID> {
 
   List<HealthCheckLogEntity> findAllByPlatformId(UUID platformId);

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckLogRepositoryImpl.java
@@ -9,6 +9,12 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+/**
+ * 클래스명: HealthCheckLogRepositoryImpl
+ * 작성자: JBumLee
+ *
+ * HealthCheckLogRepository 인터페이스의 JPA 기반 구현체
+ */
 @Repository
 @RequiredArgsConstructor
 public class HealthCheckLogRepositoryImpl implements HealthCheckLogRepository {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
@@ -19,6 +19,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
+/**
+ * 클래스명: HealthCheckPollService
+ * 작성자: JBumLee
+ *
+ * 플랫폼 헬스체크 폴링 및 상태 변화 알림 발송을 담당하는 서비스
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -32,6 +38,10 @@ public class HealthCheckPollService {
   private final SlackSender slackSender;
   private final DiscordSender discordSender;
 
+  /**
+   * 메소드이름: pollAll
+   * 활성화된 모든 플랫폼에 대해 헬스체크를 수행한다
+   */
   public void pollAll() {
     platformService.findAll().forEach(this::poll);
   }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckScheduler.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckScheduler.java
@@ -4,12 +4,22 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+/**
+ * 클래스명: HealthCheckScheduler
+ * 작성자: JBumLee
+ *
+ * 주기적으로 헬스체크를 실행하는 스케줄러
+ */
 @Component
 @RequiredArgsConstructor
 public class HealthCheckScheduler {
 
   private final HealthCheckPollService healthCheckPollService;
 
+  /**
+   * 메소드이름: run
+   * 60초마다 모든 플랫폼에 대해 헬스체크를 실행한다
+   */
   @Scheduled(fixedDelay = 60_000)
   public void run() {
     healthCheckPollService.pollAll();

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/ServiceStatusEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/ServiceStatusEntity.java
@@ -1,5 +1,11 @@
 package com.nextdv.infrastructure.healthcheck;
 
+/**
+ * 클래스명: ServiceStatusEntity
+ * 작성자: JBumLee
+ *
+ * DB 저장용 서비스 상태
+ */
 public enum ServiceStatusEntity {
   /** 정상 운영 중 */
   OPERATIONAL,

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/notification/DiscordWebhookSender.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/notification/DiscordWebhookSender.java
@@ -9,6 +9,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+/**
+ * 클래스명: DiscordWebhookSender
+ * 작성자: JBumLee
+ *
+ * Discord 웹훅을 통해 플랫폼 상태 변화 알림을 발송하는 구현체
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -16,6 +22,12 @@ public class DiscordWebhookSender implements DiscordSender {
 
   private final RestClient restClient;
 
+  /**
+   * 메소드이름: send
+   * 플랫폼 상태 변화 메시지를 Discord 채널에 POST 요청으로 발송한다
+   *
+   * @param webhookUrl Discord 웹훅 URL, platform - 상태 변화된 플랫폼, newStatus -
+   */
   @Override
   public void send(String webhookUrl, Platform platform, ServiceStatus newStatus) {
     String content = "[Heartbeat] " + platform.getName() + " 상태 변화: " + newStatus.name();

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SlackWebhookSender.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SlackWebhookSender.java
@@ -9,6 +9,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+/**
+ * 클래스명: SlackWebhookSender
+ * 작성자: JBumLee
+ *
+ * Slack 웹훅을 통해 플랫폼 상태 변화 알림을 발송하는 구현체
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -16,6 +22,12 @@ public class SlackWebhookSender implements SlackSender {
 
   private final RestClient restClient;
 
+  /**
+   * 메소드이름: send
+   * 플랫폼 상태 변화 메시지를 Slack 채널에 POST 요청으로 발송한다
+   *
+   * @param webhookUrl Slack 웹훅 URL, platform - 상태 변화된 플랫폼, newStatus - 변경된
+   */
   @Override
   public void send(String webhookUrl, Platform platform, ServiceStatus newStatus) {
     String text = "[Heartbeat] " + platform.getName() + " 상태 변화: " + newStatus.name();

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SmtpEmailSender.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SmtpEmailSender.java
@@ -9,6 +9,12 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Component;
 
+/**
+ * 클래스명: SmtpEmailSender
+ * 작성자: JBumLee
+ *
+ * SMTP를 통해 플랫폼 상태 변화 알림 이메일을 발송하는 구현체
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -16,6 +22,12 @@ public class SmtpEmailSender implements EmailSender {
 
   private final JavaMailSender mailSender;
 
+  /**
+   * 메소드이름: send
+   * 플랫폼 상태 변화 내용을 이메일로 발송한다
+   *
+   * @param address 수신자 이메일 주소, platform - 상태 변화된 플랫폼, newStatus - 변경된 상태
+   */
   @Override
   public void send(String address, Platform platform, ServiceStatus newStatus) {
     SimpleMailMessage message = new SimpleMailMessage();

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformEntity.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformEntity.java
@@ -10,6 +10,12 @@ import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.Getter;
 
+/**
+ * 클래스명: PlatformEntity
+ * 작성자: JBumLee
+ *
+ * platforms 테이블과 매핑되는 JPA 엔티티
+ */
 @Getter
 @Entity
 @Table(name = "platforms")

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformJpaRepository.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformJpaRepository.java
@@ -3,6 +3,12 @@ package com.nextdv.infrastructure.platform;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * 클래스명: PlatformJpaRepository
+ * 작성자: JBumLee
+ *
+ * platforms 테이블 JPA 저장소 인터페이스
+ */
 public interface PlatformJpaRepository
     extends
       JpaRepository<PlatformEntity, UUID> {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformRepositoryImpl.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/platform/PlatformRepositoryImpl.java
@@ -8,6 +8,12 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+/**
+ * 클래스명: PlatformRepositoryImpl
+ * 작성자: JBumLee
+ *
+ * PlatformRepository 인터페이스의 JPA 기반 구현체
+ */
 @Repository
 @RequiredArgsConstructor
 public class PlatformRepositoryImpl implements PlatformRepository {


### PR DESCRIPTION
## 변경 내용

infrastructure 레이어 전체 클래스/인터페이스에 팀 표준 JavaDoc 주석 적용

**형식**
- 클래스: `class: 이름 / 작성자: JBumLee / 설명`
- 메서드: `메소드이름 / @parameter / @return / 의도`

**대상 파일** (24개)
- JpaConfig, SchedulingConfig
- account: AccountEntity, AccountJpaRepository, AccountRepositoryImpl
- channel: ChannelEntity, ChannelJpaRepository, ChannelPlatformEntity, ChannelPlatformJpaRepository, ChannelPlatformRepositoryImpl, ChannelRepositoryImpl, ChannelTypeEntity
- healthcheck: HealthCheckLogEntity, HealthCheckLogJpaRepository, HealthCheckLogRepositoryImpl, HealthCheckPollService, HealthCheckScheduler, ServiceStatusEntity (기존 enum 상수 JavaDoc 제거)
- notification: DiscordWebhookSender, SlackWebhookSender, SmtpEmailSender
- platform: PlatformEntity, PlatformJpaRepository, PlatformRepositoryImpl

## 참고

- API 변경 없음, DB 변경 없음

Closes #111