### PR TITLE
refactor: Logback에서 Log4j2로 교체

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -2,12 +2,19 @@ plugins {
     id 'org.springframework.boot'
 }
 
+configurations {
+    all {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
+}
+
 dependencies {
     implementation project(':domain')
     runtimeOnly    project(':infrastructure')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-log4j2'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.1.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/api/src/main/java/com/nextdv/api/account/AccountController.java
+++ b/api/src/main/java/com/nextdv/api/account/AccountController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * 계정 관련 REST API 엔드포인트를 제공하는 컨트롤러
  */
+@Slf4j
 @RestController
 @RequestMapping("/accounts")
 @RequiredArgsConstructor
@@ -37,8 +39,13 @@ public class AccountController {
   @GetMapping
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<List<AccountResponse>>> list() {
+    log.info("계정 목록 조회 요청");
     List<Account> accounts = accountService.findAll();
     List<AccountResponse> data = AccountMapper.toResponseList(accounts);
+    log.info(
+        "계정 목록 조회 완료 — 건수: {}",
+        data.size()
+    );
     return ResponseEntity.ok(CommonResponse.ok(data));
   }
 
@@ -55,7 +62,15 @@ public class AccountController {
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<AccountResponse>> create(
       @Valid @RequestBody AccountRequest request) {
+    log.info(
+        "계정 생성 요청 — 이메일: {}",
+        request.getEmail()
+    );
     Account account = accountService.create(request.getEmail());
+    log.info(
+        "계정 생성 완료 — id: {}",
+        account.getId()
+    );
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(CommonResponse.ok(AccountMapper.toResponse(account)));
   }

--- a/api/src/main/java/com/nextdv/api/channel/ChannelController.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * 알림 채널 관련 REST API 엔드포인트를 제공하는 컨트롤러
  */
+@Slf4j
 @RestController
 @RequestMapping("/channels")
 public class ChannelController {
@@ -46,11 +48,21 @@ public class ChannelController {
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<ChannelResponse>> create(
       @Valid @RequestBody ChannelRequest request) {
+    log.info(
+        "채널 생성 요청 — userId: {}, type: {}, name: {}",
+        request.getUserId(),
+        request.getType(),
+        request.getName()
+    );
     Channel channel = channelService.create(
         request.getUserId(),
         request.getType(),
         request.getName(),
         request.getConfig()
+    );
+    log.info(
+        "채널 생성 완료 — id: {}",
+        channel.getId()
     );
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(CommonResponse.ok(ChannelMapper.toResponse(channel)));
@@ -67,7 +79,16 @@ public class ChannelController {
   @ApiResponse(responseCode = "400", description = "userId 파라미터 누락 또는 UUID 형식이 아님")
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<List<ChannelResponse>>> list(@RequestParam UUID userId) {
+    log.info(
+        "채널 목록 조회 요청 — userId: {}",
+        userId
+    );
     List<Channel> channels = channelService.findAllByUserId(userId);
+    log.info(
+        "채널 목록 조회 완료 — userId: {}, 건수: {}",
+        userId,
+        channels.size()
+    );
     return ResponseEntity.ok(CommonResponse.ok(ChannelMapper.toResponseList(channels)));
   }
 
@@ -83,7 +104,15 @@ public class ChannelController {
   @ApiResponse(responseCode = "404", description = "해당 ID에 해당하는 채널이 존재하지 않음")
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<Void>> delete(@PathVariable UUID id) {
+    log.info(
+        "채널 삭제 요청 — id: {}",
+        id
+    );
     channelService.delete(id);
+    log.info(
+        "채널 삭제 완료 — id: {}",
+        id
+    );
     return ResponseEntity.ok(CommonResponse.ok(null));
   }
 }

--- a/api/src/main/java/com/nextdv/api/channel/ChannelPlatformController.java
+++ b/api/src/main/java/com/nextdv/api/channel/ChannelPlatformController.java
@@ -5,6 +5,7 @@ import com.nextdv.domain.channel.ChannelPlatform;
 import com.nextdv.domain.channel.ChannelPlatformService;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * 채널-플랫폼 구독 관련 REST API 엔드포인트를 제공하는 컨트롤러
  */
+@Slf4j
 @RestController
 @RequestMapping("/channel-platforms")
 public class ChannelPlatformController {
@@ -42,9 +44,18 @@ public class ChannelPlatformController {
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<ChannelPlatformResponse>> subscribe(
       @Valid @RequestBody ChannelPlatformRequest request) {
+    log.info(
+        "구독 요청 — channelId: {}, platformId: {}",
+        request.getChannelId(),
+        request.getPlatformId()
+    );
     ChannelPlatform channelPlatform = channelPlatformService.subscribe(
         request.getChannelId(),
         request.getPlatformId()
+    );
+    log.info(
+        "구독 완료 — id: {}",
+        channelPlatform.getId()
     );
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(CommonResponse.ok(ChannelPlatformResponse.from(channelPlatform)));

--- a/api/src/main/java/com/nextdv/api/health/HealthController.java
+++ b/api/src/main/java/com/nextdv/api/health/HealthController.java
@@ -5,6 +5,7 @@ import com.nextdv.domain.health.HealthResult;
 import com.nextdv.domain.health.HealthService;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * 서버 헬스체크 엔드포인트를 제공하는 컨트롤러
  */
+@Slf4j
 @RestController
 @RequestMapping("/health")
 @RequiredArgsConstructor
@@ -32,6 +34,7 @@ public class HealthController {
   @GetMapping
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<HealthResponse>> health() {
+    log.debug("헬스 체크 요청");
     HealthResult result = healthService.check();
     return ResponseEntity.ok(CommonResponse.ok(HealthMapper.toResponse(result)));
   }

--- a/api/src/main/java/com/nextdv/api/healthcheck/PlatformStatusController.java
+++ b/api/src/main/java/com/nextdv/api/healthcheck/PlatformStatusController.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * 플랫폼 헬스체크 상태 조회 REST API 엔드포인트를 제공하는 컨트롤러
  */
+@Slf4j
 @RestController
 @RequestMapping("/platforms")
 @RequiredArgsConstructor
@@ -40,12 +42,18 @@ public class PlatformStatusController {
   @ApiResponse(responseCode = "404", description = "해당 ID에 해당하는 플랫폼이 존재하지 않음")
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<HealthCheckLogResponse>> getStatus(@PathVariable UUID id) {
+    log.info(
+        "플랫폼 상태 조회 요청 — platformId: {}",
+        id
+    );
     platformService
         .findById(id)
         .orElseThrow(() -> new NoSuchElementException("플랫폼을 찾을 수 없습니다."));
     return healthCheckLogService
         .findLatestByPlatformId(id)
-        .map(log -> ResponseEntity.ok(CommonResponse.ok(HealthCheckLogMapper.toResponse(log))))
+        .map(
+            latest -> ResponseEntity.ok(CommonResponse.ok(HealthCheckLogMapper.toResponse(latest)))
+        )
         .orElse(ResponseEntity.ok(CommonResponse.ok(null)));
   }
 
@@ -62,6 +70,10 @@ public class PlatformStatusController {
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<List<HealthCheckLogResponse>>> getLogs(
       @PathVariable UUID id) {
+    log.info(
+        "플랫폼 로그 조회 요청 — platformId: {}",
+        id
+    );
     platformService
         .findById(id)
         .orElseThrow(() -> new NoSuchElementException("플랫폼을 찾을 수 없습니다."));

--- a/api/src/main/java/com/nextdv/api/platform/PlatformController.java
+++ b/api/src/main/java/com/nextdv/api/platform/PlatformController.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * 플랫폼 조회 REST API 엔드포인트를 제공하는 컨트롤러
  */
+@Slf4j
 @RestController
 @RequestMapping("/platforms")
 @RequiredArgsConstructor
@@ -36,7 +38,12 @@ public class PlatformController {
   @GetMapping
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<List<PlatformResponse>>> list() {
+    log.info("플랫폼 목록 조회 요청");
     List<Platform> platforms = platformService.findAll();
+    log.info(
+        "플랫폼 목록 조회 완료 — 건수: {}",
+        platforms.size()
+    );
     return ResponseEntity.ok(CommonResponse.ok(PlatformMapper.toResponseList(platforms)));
   }
 
@@ -52,6 +59,10 @@ public class PlatformController {
   @ApiResponse(responseCode = "404", description = "해당 ID에 해당하는 플랫폼이 존재하지 않음")
   @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   public ResponseEntity<CommonResponse<PlatformResponse>> findById(@PathVariable UUID id) {
+    log.info(
+        "플랫폼 조회 요청 — id: {}",
+        id
+    );
     Platform platform = platformService
         .findById(id)
         .orElseThrow(() -> new NoSuchElementException("플랫폼을 찾을 수 없습니다."));

--- a/api/src/main/resources/log4j2.xml
+++ b/api/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/domain/src/main/java/com/nextdv/domain/account/AccountService.java
+++ b/domain/src/main/java/com/nextdv/domain/account/AccountService.java
@@ -3,6 +3,7 @@ package com.nextdv.domain.account;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /**
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
  *
  * 계정 생성 및 조회 비즈니스 로직을 담당하는 서비스
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AccountService {
@@ -24,7 +26,12 @@ public class AccountService {
    * @return 전체 계정 목록
    */
   public List<Account> findAll() {
-    return accountRepository.findAll();
+    List<Account> accounts = accountRepository.findAll();
+    log.info(
+        "계정 전체 조회 — 건수: {}",
+        accounts.size()
+    );
+    return accounts;
   }
 
   /**
@@ -36,11 +43,22 @@ public class AccountService {
    */
   public Account create(String email) {
     if (email == null || email.isBlank()) {
+      log.warn("계정 생성 실패 — 이메일 누락");
       throw new IllegalArgumentException("이메일은 필수입니다.");
     }
     if (accountRepository.existsByEmail(email)) {
+      log.warn(
+          "계정 생성 실패 — 중복 이메일: {}",
+          email
+      );
       throw new IllegalStateException("이미 사용 중인 이메일입니다.");
     }
-    return accountRepository.save(new Account(UUID.randomUUID(), email));
+    Account account = accountRepository.save(new Account(UUID.randomUUID(), email));
+    log.info(
+        "계정 생성 — id: {}, 이메일: {}",
+        account.getId(),
+        email
+    );
+    return account;
   }
 }

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformService.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelPlatformService.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /**
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
  *
  * 채널-플랫폼 구독 비즈니스 로직을 담당하는 서비스
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChannelPlatformService {
@@ -31,18 +33,42 @@ public class ChannelPlatformService {
   public ChannelPlatform subscribe(UUID channelId, UUID platformId) {
     channelRepository
         .findById(channelId)
-        .orElseThrow(() -> new NoSuchElementException("채널을 찾을 수 없습니다."));
+        .orElseThrow(() -> {
+          log.warn(
+              "구독 실패 — 존재하지 않는 channelId: {}",
+              channelId
+          );
+          return new NoSuchElementException("채널을 찾을 수 없습니다.");
+        });
     platformRepository
         .findById(platformId)
-        .orElseThrow(() -> new NoSuchElementException("플랫폼을 찾을 수 없습니다."));
+        .orElseThrow(() -> {
+          log.warn(
+              "구독 실패 — 존재하지 않는 platformId: {}",
+              platformId
+          );
+          return new NoSuchElementException("플랫폼을 찾을 수 없습니다.");
+        });
     if (channelPlatformRepository.existsByChannelIdAndPlatformId(
         channelId,
         platformId
     )) {
+      log.warn(
+          "구독 실패 — 이미 구독 중 channelId: {}, platformId: {}",
+          channelId,
+          platformId
+      );
       throw new IllegalStateException("이미 구독 중입니다.");
     }
-    return channelPlatformRepository.save(
+    ChannelPlatform saved = channelPlatformRepository.save(
         new ChannelPlatform(UUID.randomUUID(), channelId, platformId, Instant.now())
     );
+    log.info(
+        "구독 완료 — id: {}, channelId: {}, platformId: {}",
+        saved.getId(),
+        channelId,
+        platformId
+    );
+    return saved;
   }
 }

--- a/domain/src/main/java/com/nextdv/domain/channel/ChannelService.java
+++ b/domain/src/main/java/com/nextdv/domain/channel/ChannelService.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /**
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
  *
  * 알림 채널 생성, 조회, 삭제 비즈니스 로직을 담당하는 서비스
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChannelService {
@@ -35,7 +37,14 @@ public class ChannelService {
     );
     Instant now = Instant.now();
     Channel channel = new Channel(UUID.randomUUID(), userId, type, name, config, now, now, null);
-    return channelRepository.save(channel);
+    Channel saved = channelRepository.save(channel);
+    log.info(
+        "채널 생성 — id: {}, userId: {}, type: {}",
+        saved.getId(),
+        userId,
+        type
+    );
+    return saved;
   }
 
   private void validateConfig(ChannelType type, Map<String, Object> config) {
@@ -71,7 +80,13 @@ public class ChannelService {
    * @return 해당 사용자의 채널 목록
    */
   public List<Channel> findAllByUserId(UUID userId) {
-    return channelRepository.findAllByUserId(userId);
+    List<Channel> channels = channelRepository.findAllByUserId(userId);
+    log.info(
+        "채널 조회 — userId: {}, 건수: {}",
+        userId,
+        channels.size()
+    );
+    return channels;
   }
 
   /**
@@ -83,7 +98,13 @@ public class ChannelService {
   public void delete(UUID id) {
     Channel channel = channelRepository
         .findById(id)
-        .orElseThrow(() -> new NoSuchElementException("채널을 찾을 수 없습니다."));
+        .orElseThrow(() -> {
+          log.warn(
+              "채널 삭제 실패 — 존재하지 않는 id: {}",
+              id
+          );
+          return new NoSuchElementException("채널을 찾을 수 없습니다.");
+        });
     Channel deleted = new Channel(
         channel.getId(),
         channel.getUserId(),
@@ -95,5 +116,9 @@ public class ChannelService {
         Instant.now()
     );
     channelRepository.save(deleted);
+    log.info(
+        "채널 삭제 — id: {}",
+        id
+    );
   }
 }

--- a/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLogService.java
+++ b/domain/src/main/java/com/nextdv/domain/healthcheck/HealthCheckLogService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /**
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
  *
  * 헬스체크 로그 조회 비즈니스 로직을 담당하는 서비스
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class HealthCheckLogService {
@@ -26,6 +28,10 @@ public class HealthCheckLogService {
    * @return 가장 최근 헬스체크 로그 (없으면 empty)
    */
   public Optional<HealthCheckLog> findLatestByPlatformId(UUID platformId) {
+    log.info(
+        "최신 헬스체크 로그 조회 — platformId: {}",
+        platformId
+    );
     return healthCheckLogRepository.findLatestByPlatformId(platformId);
   }
 
@@ -37,6 +43,12 @@ public class HealthCheckLogService {
    * @return 해당 플랫폼의 전체 헬스체크 로그 목록
    */
   public List<HealthCheckLog> findAllByPlatformId(UUID platformId) {
-    return healthCheckLogRepository.findAllByPlatformId(platformId);
+    List<HealthCheckLog> logs = healthCheckLogRepository.findAllByPlatformId(platformId);
+    log.info(
+        "헬스체크 로그 전체 조회 — platformId: {}, 건수: {}",
+        platformId,
+        logs.size()
+    );
+    return logs;
   }
 }

--- a/domain/src/main/java/com/nextdv/domain/platform/PlatformService.java
+++ b/domain/src/main/java/com/nextdv/domain/platform/PlatformService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /**
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
  *
  * 플랫폼 조회 비즈니스 로직을 담당하는 서비스
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PlatformService {
@@ -25,7 +27,12 @@ public class PlatformService {
    * @return 활성화된 플랫폼 목록
    */
   public List<Platform> findAll() {
-    return platformRepository.findAll(true);
+    List<Platform> platforms = platformRepository.findAll(true);
+    log.info(
+        "플랫폼 전체 조회 — 건수: {}",
+        platforms.size()
+    );
+    return platforms;
   }
 
   /**
@@ -36,6 +43,13 @@ public class PlatformService {
    * @return 플랫폼 객체 (없으면 empty)
    */
   public Optional<Platform> findById(UUID id) {
-    return platformRepository.findById(id);
+    Optional<Platform> platform = platformRepository.findById(id);
+    if (platform.isEmpty()) {
+      log.warn(
+          "플랫폼 조회 결과 없음 — id: {}",
+          id
+      );
+    }
+    return platform;
   }
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckPollService.java
@@ -43,7 +43,9 @@ public class HealthCheckPollService {
    * 활성화된 모든 플랫폼에 대해 헬스체크를 수행한다
    */
   public void pollAll() {
+    log.info("전체 플랫폼 헬스체크 시작");
     platformService.findAll().forEach(this::poll);
+    log.info("전체 플랫폼 헬스체크 완료");
   }
 
   private void poll(Platform platform) {
@@ -78,7 +80,21 @@ public class HealthCheckPollService {
       responseMs = (int) (System.currentTimeMillis() - startMs);
       httpStatusCode = null;
       status = ServiceStatus.MAJOR_OUTAGE;
+      log.warn(
+          "헬스체크 연결 실패 — platformId: {}, url: {}",
+          platform.getId(),
+          platform.getHealthCheckUrl(),
+          e
+      );
     }
+
+    log.info(
+        "헬스체크 결과 — platformId: {}, status: {}, httpStatus: {}, 응답시간: {}ms",
+        platform.getId(),
+        status,
+        httpStatusCode,
+        responseMs
+    );
 
     notifyStatusChange(
         platform,
@@ -97,6 +113,12 @@ public class HealthCheckPollService {
     if (previous == null || previous == current) {
       return;
     }
+    log.warn(
+        "플랫폼 상태 변경 — platformId: {}, {} → {}",
+        platform.getId(),
+        previous,
+        current
+    );
     channelRepository.findEmailChannelsByPlatformId(platform.getId()).forEach(channel -> {
       String address = (String) channel.getConfig().get("address");
       try {

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckScheduler.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/healthcheck/HealthCheckScheduler.java
@@ -1,6 +1,7 @@
 package com.nextdv.infrastructure.healthcheck;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Component;
  *
  * 주기적으로 헬스체크를 실행하는 스케줄러
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class HealthCheckScheduler {
@@ -22,6 +24,8 @@ public class HealthCheckScheduler {
    */
   @Scheduled(fixedDelay = 60_000)
   public void run() {
+    log.info("헬스체크 스케줄러 시작");
     healthCheckPollService.pollAll();
+    log.info("헬스체크 스케줄러 종료");
   }
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/notification/DiscordWebhookSender.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/notification/DiscordWebhookSender.java
@@ -30,6 +30,11 @@ public class DiscordWebhookSender implements DiscordSender {
    */
   @Override
   public void send(String webhookUrl, Platform platform, ServiceStatus newStatus) {
+    log.info(
+        "Discord 알림 발송 — 플랫폼: {}, 상태: {}",
+        platform.getName(),
+        newStatus.name()
+    );
     String content = "[Heartbeat] " + platform.getName() + " 상태 변화: " + newStatus.name();
     restClient
         .post()
@@ -42,5 +47,9 @@ public class DiscordWebhookSender implements DiscordSender {
         )
         .retrieve()
         .toBodilessEntity();
+    log.info(
+        "Discord 알림 발송 완료 — 플랫폼: {}",
+        platform.getName()
+    );
   }
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SlackWebhookSender.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SlackWebhookSender.java
@@ -30,6 +30,11 @@ public class SlackWebhookSender implements SlackSender {
    */
   @Override
   public void send(String webhookUrl, Platform platform, ServiceStatus newStatus) {
+    log.info(
+        "Slack 알림 발송 — 플랫폼: {}, 상태: {}",
+        platform.getName(),
+        newStatus.name()
+    );
     String text = "[Heartbeat] " + platform.getName() + " 상태 변화: " + newStatus.name();
     restClient
         .post()
@@ -42,5 +47,9 @@ public class SlackWebhookSender implements SlackSender {
         )
         .retrieve()
         .toBodilessEntity();
+    log.info(
+        "Slack 알림 발송 완료 — 플랫폼: {}",
+        platform.getName()
+    );
   }
 }

--- a/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SmtpEmailSender.java
+++ b/infrastructure/src/main/java/com/nextdv/infrastructure/notification/SmtpEmailSender.java
@@ -30,6 +30,12 @@ public class SmtpEmailSender implements EmailSender {
    */
   @Override
   public void send(String address, Platform platform, ServiceStatus newStatus) {
+    log.info(
+        "이메일 알림 발송 — 수신자: {}, 플랫폼: {}, 상태: {}",
+        address,
+        platform.getName(),
+        newStatus.name()
+    );
     SimpleMailMessage message = new SimpleMailMessage();
     message.setTo(address);
     message.setSubject("[Heartbeat] " + platform.getName() + " 상태 변화: " + newStatus.name());
@@ -38,5 +44,9 @@ public class SmtpEmailSender implements EmailSender {
             + "URL: " + platform.getHealthCheckUrl()
     );
     mailSender.send(message);
+    log.info(
+        "이메일 알림 발송 완료 — 수신자: {}",
+        address
+    );
   }
 }


### PR DESCRIPTION
## 변경 내용

기본 로깅 구현체를 Logback에서 Log4j2로 교체

- `api/build.gradle`: `spring-boot-starter-logging` 제외, `spring-boot-starter-log4j2` 추가
- `api/src/main/resources/log4j2.xml`: 콘솔 출력, INFO 레벨 기본 설정

## 참고

- 기존 `@Slf4j` 어노테이션 그대로 유지 (SLF4J 인터페이스 변경 없음)
- API 변경 없음, DB 변경 없음

Closes #112